### PR TITLE
chore(marketplace): add description; foreground learning + context engineering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,12 @@
 {
   "name": "pipecrew",
   "owner": { "name": "Ramy Hassan" },
+  "description": "PipeCrew — a multi-repo agent crew for Claude Code that discovers a platform and ships features end-to-end across backend, frontend, mock, and infra repos. The crew learns your platform: it engineers durable, agent-facing context from your codebase (conventions, contracts, architecture) and keeps learning from every run and merged PR, so each feature lands better-grounded than the last.",
   "plugins": [
     {
       "name": "pipecrew",
       "source": "./",
-      "description": "Multi-repo agent crew for Claude Code — /discover, /deliver, /review, /assess, /context-refresh."
+      "description": "Multi-repo agent crew for Claude Code that learns your platform — /discover, /deliver, /review, /assess, plus /learn and /context-refresh to engineer durable agent-facing context that improves every run."
     }
   ]
 }


### PR DESCRIPTION
Adds a top-level marketplace `description` (clears the `claude plugin validate` warning) and reframes both the marketplace and plugin-entry descriptions around the crew **learning your platform** and **engineering durable agent-facing context** from your codebase + every run and merged PR.

Prep for submitting PipeCrew to the `claude-community` marketplace via the Console form.

- `claude plugin validate` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)