### PR TITLE
chore: fix license to Apache-2.0; add PRIVACY.md

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/pipecrew-ai/pipecrew",
   "repository": "https://github.com/pipecrew-ai/pipecrew",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "pipecrew",
     "feature-pipeline",

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,31 @@
+# Privacy Policy
+
+_Last updated: 2026-06-22_
+
+**PipeCrew** is a plugin for [Claude Code](https://claude.ai/claude-code) that runs
+locally on your own machine. It does not collect, store, or transmit any personal
+data.
+
+## What PipeCrew does
+
+- Runs entirely on your local machine as a Claude Code plugin.
+- Reads and writes files only in the repositories and workspace directories you
+  point it at.
+- Has no backend service of its own, no analytics, no telemetry, and no
+  account system. The plugin author receives no data from your use of it.
+
+## Data handled by the underlying tools
+
+PipeCrew orchestrates Claude Code, which sends prompts and code context to
+Anthropic's models to perform its work. That processing is governed by
+Anthropic's own terms and privacy policy, not by this plugin:
+
+- Anthropic Privacy Policy: https://www.anthropic.com/legal/privacy
+
+If your workflow uses PipeCrew to open pull requests or push to GitHub (via the
+`gh` CLI or git), that activity is governed by the privacy policies of those
+services.
+
+## Contact
+
+Questions about this policy: **ramy.7assan@gmail.com**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ context and learning your platform, so **every run starts smarter than the last*
 [![Website](https://img.shields.io/badge/pipecrew.ai-website-2563eb)](https://pipecrew.ai)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757)](https://claude.ai/claude-code)
 [![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/pipecrew-ai/pipecrew)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](#license)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 
 [**Website**](https://pipecrew.ai) · [**Install**](#install) · [**Quick start**](#quick-start) · [**Skills**](#skills) · [**Supported stacks**](#supported-tech-stacks)
 
@@ -280,4 +280,4 @@ or via `/update-config`.
 
 ## License
 
-[MIT](#license) · Learn more at **[pipecrew.ai](https://pipecrew.ai)**
+[Apache 2.0](LICENSE) · Learn more at **[pipecrew.ai](https://pipecrew.ai)**


### PR DESCRIPTION
Aligns the declared license with the actual `LICENSE` file and adds a privacy policy for the community-marketplace submission.

- `plugin.json` + README badge/footer said **MIT**, but the `LICENSE` file is **Apache 2.0**. Updated the manifest and README to `Apache-2.0` to match the legally-operative file.
- Added `PRIVACY.md`: the plugin runs locally and collects no data; underlying model calls are governed by Anthropic''s policy.
- `claude plugin validate` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)