### PR TITLE
docs(readme): add PIPECREW binary wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ context and learning your platform, so **every run starts smarter than the last*
 
 </div>
 
+```
+1110 111 1110 1111 0111 1110 1111 10001
+1001 010 1001 1000 1000 1001 1000 10001
+1110 010 1110 1110 1000 1110 1110 10101
+1000 010 1000 1000 1000 1010 1000 10101
+1000 111 1000 1111 0111 1001 1111 01010
+ P    I   P    E    C    R    E     W
+```
+
 ---
 
 > **Not a faster one-shot agent** — a crew that fans out across your repos, engineers its own


### PR DESCRIPTION
Adds a terminal-style binary block wordmark of **PIPECREW** below the header — the `1`s form the letters, `0`s the background, with a letter-label row underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)