### PR TITLE
docs(readme): center block wordmark under the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 <img src="assets/pipecrew-logo.svg" alt="PipeCrew logo" width="160" height="160" />
 
-# PipeCrew
+<pre>
+██████   ██████  ██████   ██████   █████  ██████   ██████  ██   ██
+██   ██    ██    ██   ██  ██      ██      ██   ██  ██      ██   ██
+██████     ██    ██████   █████   ██      ██████   █████   ██ █ ██
+██         ██    ██       ██      ██      ██  ██   ██      ███████
+██       ██████  ██       ██████   █████  ██   ██  ██████   ██ ██ 
+</pre>
 
 ### A crew that learns your platform
 
@@ -18,14 +24,6 @@ context and learning your platform, so **every run starts smarter than the last*
 [**Website**](https://pipecrew.ai) · [**Install**](#install) · [**Quick start**](#quick-start) · [**Skills**](#skills) · [**Supported stacks**](#supported-tech-stacks)
 
 </div>
-
-```
-██████   ██████  ██████   ██████   █████  ██████   ██████  ██   ██
-██   ██    ██    ██   ██  ██      ██      ██   ██  ██      ██   ██
-██████     ██    ██████   █████   ██      ██████   █████   ██ █ ██
-██         ██    ██       ██      ██      ██  ██   ██      ███████
-██       ██████  ██       ██████   █████  ██   ██  ██████   ██ ██
-```
 
 ---
 


### PR DESCRIPTION
Moves the solid-block PIPECREW banner into the centered header as a `<pre>` directly under the logo, replacing the text `# PipeCrew` H1. Banner lines are padded to equal width so they stay aligned when GitHub center-aligns the `<pre>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)