### PR TITLE
fix(discover): substitute runtime tokens in generated domain agents + template drift

### DIFF
--- a/skills/discover/phases/phase-c-generation.md
+++ b/skills/discover/phases/phase-c-generation.md
@@ -185,7 +185,9 @@ Replace placeholders using data from B1 + B2:
 |-------------|--------|
 | `{{WORKSPACE_SLUG}}` | workspace config |
 | `{{WORKSPACE_NAME}}` | workspace config |
-| `{{QUALITY_STANDARDS}}` | Default quality bar (can be customized later). Include: "Backend: all spec endpoints implemented, DTOs match, tests cover happy path + main error. Frontend: all FR- requirements implemented, types match spec, i18n both languages. Mock: all endpoints covered, shapes match spec." |
+| `{workspace_root}` | Absolute workspace root — run `node {plugin_dir}/scripts/workspace-root.js --get` and substitute the value verbatim, normalized to forward slashes (e.g. `C:/ABVI/pipecrew-workspaces`). **This is a single-brace *runtime* token and it MUST be substituted now, at generation time.** A dispatched agent reads its own system prompt verbatim — the orchestrator's runtime token substitution never touches a sub-agent's baked-in prompt — so a leftover `{workspace_root}` is an unresolvable path at runtime: the agent guesses (e.g. `~/.claude/{slug}-context/...`) and reads the wrong file or nothing. |
+| `{plugin_dir}` | Absolute path to this plugin directory (normalized to forward slashes). Substitute verbatim so `node {plugin_dir}/scripts/...` and doc references baked into the agent (e.g. the troubleshooter's `extract-block.js` call, the product-owner's block-schema references) resolve at runtime. Same single-brace runtime-token rule as `{workspace_root}`. |
+| `{{QUALITY_STANDARDS}}` | **Assessor only.** Default quality bar (can be customized later). Include: "Backend: all spec endpoints implemented, DTOs match, tests cover happy path + main error. Frontend: all FR- requirements implemented, types match spec, i18n both languages. Mock: all endpoints covered, shapes match spec." Do **not** inject into the troubleshooter — it is a read-only incident-triage agent, not a quality gate; its template no longer carries this placeholder. |
 
 Note: the older `{{DOMAIN_CONTEXT}}` and `{{DESIGN_SYSTEM_CONTEXT}}` placeholders were removed from the templates. Agents now read `{workspace_root}/{slug}/context/platform.md` and `design-system.md` directly at dispatch time. This keeps the agents' knowledge always fresh (no summary-drift risk) and leaves no baked-in copy of workspace context to go stale between onboarding refreshes. If older templates with these placeholders are encountered, treat them as pointers — replace their value with the "read the file" instruction already present in the current templates.
 
@@ -238,14 +240,15 @@ Placeholders may appear more than once in a template (e.g., a shared slug refere
 
 - When using `Edit`, pass `replace_all: true` for every placeholder replacement.
 - When using `sed`, use the `g` flag (`s|{{PLACEHOLDER}}|value|g`).
+- The single-brace **runtime tokens** `{workspace_root}` and `{plugin_dir}` must be substituted globally too (their absolute values from the table above) — they are easy to miss because they don't use the `{{…}}` form, and a leftover one is a silent runtime failure, not a visible placeholder.
 
-After writing each agent file, verify zero placeholders remain:
+After writing each agent file, verify no placeholders **and no unresolved runtime tokens** remain:
 
 ```bash
-grep -c '{{' {workspace_root}/{slug}/agents/{product-owner,assessor,troubleshooter}.md
+grep -cE '\{\{|\{(workspace_root|plugin_dir|slug)\}' {workspace_root}/{slug}/agents/{product-owner,assessor,troubleshooter}.md
 ```
 
-Every file must report `0`. If any file reports ≥1, halt, run `grep -n '{{' <file>` to list remaining placeholders by line, and fix before continuing. Do **not** ship an agent file with an unfilled placeholder — it will produce confusing behavior at runtime when the agent reads its own system prompt.
+Every file must report `0`. If any file reports ≥1, halt, run `grep -nE '\{\{|\{(workspace_root|plugin_dir|slug)\}' <file>` to list the remaining placeholders/tokens by line, and fix before continuing. Do **not** ship an agent file with an unfilled `{{placeholder}}` or an unresolved single-brace `{workspace_root}` / `{plugin_dir}` / `{slug}` token — both produce confusing or broken behavior at runtime when the agent reads its own system prompt.
 
 **Update scratchpad**: set `Domain agents` to COMPLETED in `## Generation Status`.
 

--- a/templates/agents/assessor.md.template
+++ b/templates/agents/assessor.md.template
@@ -6,7 +6,7 @@ model: opus
 
 You are a **cross-repo** quality assessor for the **{{WORKSPACE_NAME}}** platform. You assess the full output of a feature pipeline spanning backend services, frontend, and mock server.
 
-**First**: Read `{workspace_root}/{{WORKSPACE_SLUG}}/context/platform.md` for platform architecture, service boundaries, and tech stacks.
+**First — your inputs depend on how you were dispatched; read only what you are given.** A standalone `/assess` run hands you a platform-context path (`{workspace_root}/{{WORKSPACE_SLUG}}/context/platform.md`) and, when they exist, the requirements + technical-design docs — read them. A `/deliver` Phase 6 dispatch deliberately **narrows** your inputs (spec diffs, the Phase 5.5 code-review report, a pre-computed endpoint inventory, and the files-changed list) and explicitly tells you **not** to read `platform.md` or re-read requirements/architecture — honor that. In both modes: work only from the inputs your dispatch names, and never block waiting for a file you were not given.
 
 ## Role boundary — what you are and are NOT
 
@@ -22,13 +22,10 @@ You are a **cross-repo** quality assessor for the **{{WORKSPACE_NAME}}** platfor
 
 ## Your Role
 
-You receive:
-1. The approved requirements document (Phase 1 output)
-2. The technical design document (Phase 2 output)
-3. A list of repos and files modified in each parallel phase
-4. The updated OpenAPI spec (Phase 3 output)
-5. The Phase 5.5 code review report
-6. **Implementation task statuses** — which tasks are COMPLETED, BLOCKED, SKIPPED, or FAILED
+Your exact inputs vary by dispatch — read what you are given, do not assume the full set:
+- **Always**: implementation task statuses (COMPLETED / BLOCKED / SKIPPED / FAILED), the updated OpenAPI spec(s), the Phase 5.5 code-review report, and a files-modified list per repo.
+- **`/deliver` Phase 6 (narrowed)**: you also get a pre-computed endpoint inventory to use as your wire-shape checklist. You do **not** receive — and must not re-read — the requirements doc, the technical design, or `platform.md`; if you need a specific FR/EC detail, take it from the code-review report, which maps findings to requirements. This is a deliberate scope narrowing.
+- **`/assess` (standalone)**: you also get the requirements doc and technical design when they exist, plus a platform-context path.
 
 You then read the actual implementation files across repos and assess **cross-repo integration**, not per-file craft.
 
@@ -43,8 +40,8 @@ For each task:
 - **BLOCKED/FAILED**: Record as deployment blocker. Overall score CANNOT be PASS.
 - **SKIPPED**: Record as "SKIPPED" with reason.
 
-### Step 1: Read context + build checklist
-Read the requirements and technical design. Build a checklist of what to verify across repos.
+### Step 1: Build the cross-repo checklist from your provided inputs
+Build a checklist of what to verify across repos from the inputs you were given — the endpoint inventory plus the FR/EC mapping inside the code-review report on a `/deliver` Phase 6 dispatch; the requirements + technical design when a standalone `/assess` provided them. Do not request re-reads of files outside your dispatch's named input set.
 
 ### Step 2: Wire-shape agreement (backend ↔ frontend ↔ mock)
 For every new or modified endpoint, open the backend DTO and frontend TypeScript type side by side. Field names, required fields, optionality, enum values must all match. Verify mock handler response shapes match real backend.

--- a/templates/agents/troubleshooter.md.template
+++ b/templates/agents/troubleshooter.md.template
@@ -225,5 +225,3 @@ Write the report to `{run_dir}/report.md` (orchestrator provides `{run_dir}`). R
 ## Runbook update candidate (optional)
 {If this incident teaches a lesson worth saving, propose a one-paragraph runbook entry. The user can accept it via `/troubleshoot --learn` to be appended to platform.md / docs/runbooks/.}
 ```
-
-{{QUALITY_STANDARDS}}


### PR DESCRIPTION
## Problems fixed

**C1 — unresolved `{workspace_root}` / `{plugin_dir}` in generated agents.** Phase C Step 3 only substituted `{{double-brace}}` placeholders, and its leftover-check grepped only for `{{`. The single-brace **runtime** tokens survived into the generated domain agents. A dispatched sub-agent reads its own system prompt verbatim, so the unresolved `{workspace_root}` became a path the agent *guessed* at runtime (e.g. `~/.claude/{slug}-context/platform.md`) — reading the wrong file or nothing.
- Now both tokens are substituted at generation time (`workspace-root.js --get`, forward-slash normalized), and the verify grep catches single-brace `{workspace_root}`/`{plugin_dir}`/`{slug}` too.

**C2 — assessor template/dispatch drift.** The template asserted it always receives requirements + technical design and reads `platform.md` — true for standalone `/assess`, but the `/deliver` Phase 6 dispatch deliberately withholds them (and forbids re-reading). Reframed the template's inputs as **dispatch-driven** so it's correct in both modes.

**C7 (bug) — `{{QUALITY_STANDARDS}}` mis-injection.** A quality bar meaningful only to the assessor was injected into the read-only troubleshooter. Removed from the troubleshooter template; Phase C marks the placeholder assessor-only.

## Deferred to a follow-up
- C6: template-version stamp + Phase D staleness warning (independent enhancement).
- C7: R1-R6 prose simplification (pure cleanup).

## Note
This fixes the **generator**. Already-generated workspace agents stay broken until regenerated (`/discover --resume --workspace=<slug>`) or hand-patched.

## Tests
Full eval suite green (`eval/tests/*`), incl. template/script/skill ref resolution and agent-role parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)