### PR TITLE
feat(deliver): surface workspace-permission setup at pre-flight + cover builds/MCP

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -158,9 +158,19 @@ writes/merges a `.claude/settings.local.json` there with:
   any repo from inside another no longer prompts. Because Claude Code walks up
   from the launch cwd to find settings, one file at the shared parent loads for
   **every** repo and worktree beneath it.
-- a **safe-only** allowlist (Edit/Write, read-only + local-only git, build/test/read).
-  `git push`, `reset --hard`, `clean`, `rm`, deploys, and `docker push` are
-  deliberately omitted, so they keep prompting.
+- a **safe-only** allowlist (Edit/Write, read-only + local-only git, the `git
+  worktree` lifecycle the pipeline drives, build/test for the common stacks, read
+  tools, and the Phase-6 `chrome-devtools` MCP `mcp__chrome-devtools__*` for live
+  browser verification). `git push`, `reset --hard`, `clean`, `rm`, deploys,
+  `docker push`, and language `install`/`publish` subcommands (`go install`,
+  `cargo install`/`publish`, `npm publish`, `dotnet nuget push`) are deliberately
+  omitted, so they keep prompting.
+
+Both `/discover` Step 3.5 and **`/deliver` pre-flight** surface this helper: pre-flight
+runs it in `--dry-run` and, if the workspace has no allowlist yet, prints the exact
+command to run (then a `claude` restart loads it). This is what stops the cross-repo
+edit flood, the dispatched-agent ADR write being denied under `context/adrs/`, the
+backend-compile prompt, and the Phase-6 browser-verification MCP prompts.
 
 It MERGES (union, order-stable) and never clobbers a hand-curated file; an
 unparseable existing file is left untouched. Re-runnable on an already-onboarded

--- a/scripts/setup-workspace-permissions.js
+++ b/scripts/setup-workspace-permissions.js
@@ -138,8 +138,35 @@ const SAFE_ALLOW = [
   'Bash(./mvnw:*)',
   'Bash(mvn:*)',
   'Bash(./gradlew:*)',
+  'Bash(gradle:*)',
   'Bash(pytest:*)',
+  'Bash(python -m pytest:*)',
+  'Bash(python3 -m pytest:*)',
+  'Bash(poetry run:*)',
+  'Bash(ruff:*)',
+  'Bash(mypy:*)',
+  // Build/test for additional stacks — verb-scoped so the dangerous subcommands
+  // (go/cargo/dotnet install/publish/nuget push) keep prompting.
   'Bash(go test:*)',
+  'Bash(go build:*)',
+  'Bash(go vet:*)',
+  'Bash(cargo build:*)',
+  'Bash(cargo test:*)',
+  'Bash(cargo check:*)',
+  'Bash(dotnet build:*)',
+  'Bash(dotnet test:*)',
+  'Bash(npx jest:*)',
+  'Bash(npx prettier:*)',
+  // The /deliver orchestrator drives worktree lifecycle (add/remove/list) and
+  // diffs against the merge-base — worktrees are disposable, merge-base is read-only.
+  'Bash(git worktree:*)',
+  'Bash(git merge-base:*)',
+  // The plugin's own zero-dep scripts (gate.js, extract-block.js, validate-*.js, …).
+  'Bash(node *pipecrew/scripts/*)',
+  // chrome-devtools MCP — Phase 6 live browser verification (navigate / click /
+  // screenshot / read console+network). Server name matches scripts/ensure-mcp.js
+  // (`--name=chrome-devtools`); the assessor only drives it against localhost.
+  'mcp__chrome-devtools__*',
   // Read / inspect.
   'Bash(ls:*)',
   'Bash(cat:*)',

--- a/scripts/setup-workspace-permissions.test.js
+++ b/scripts/setup-workspace-permissions.test.js
@@ -85,6 +85,23 @@ test('allow-list is safe-only: includes Edit + git commit, excludes push/rm/depl
   assert(!/cdk deploy|terraform apply|docker push/.test(joined), 'deploys must NOT be allowed');
 });
 
+test('allow-list covers build stacks, worktrees, and the chrome-devtools MCP — still safe-only', () => {
+  const ws = makeWorkspace();
+  run(ws.configPath);
+  const allow = readSettings(ws.reposParent).permissions.allow;
+  // E10: Phase 6 browser verification MCP is pre-allowed.
+  assert(allow.includes('mcp__chrome-devtools__*'), 'chrome-devtools MCP not allowed');
+  // E9 + worktree friction: build verbs and worktree lifecycle present.
+  assert(allow.some((a) => a.includes('gradle')), 'gradle not allowed');
+  assert(allow.some((a) => a.includes('git worktree')), 'git worktree not allowed');
+  assert(allow.some((a) => a.includes('git merge-base')), 'git merge-base not allowed');
+  // The newly-added stack verbs must NOT have opened install/publish subcommands.
+  const joined = allow.join('\n');
+  assert(!/go install|cargo install|cargo publish|dotnet nuget|dotnet publish/.test(joined),
+    'install/publish subcommands must NOT be allowed');
+  assert(!/git push/.test(joined), 'git push must NOT be allowed');
+});
+
 test('merges into an existing file without clobbering, union is order-stable', () => {
   const ws = makeWorkspace();
   const claudeDir = path.join(ws.reposParent, '.claude');

--- a/skills/deliver/phases/pre-flight.md
+++ b/skills/deliver/phases/pre-flight.md
@@ -343,13 +343,30 @@ auto-opens the browser, reads `scratchpad.md` + `checkpoints.jsonl` +
 
 Do not wait for the server process to finish. Continue immediately to Phase 1.
 
-**One-time permission tip (print once, then proceed).** Phase 5 implementers each make dozens of `Bash`/`Edit`/`Write` calls, and Claude Code prompts to approve each one that isn't pre-approved — this is separate from the pipeline's own approval gates and is the usual cause of "why am I being asked so much during implementation?". Print this single line in chat after launching the site-view, then continue (do NOT block on it):
+**One-time permission setup (check + tip — print once, then proceed).** Phase 5 implementers each make dozens of `Bash`/`Edit`/`Write` calls, and Claude Code prompts to approve each one that isn't pre-approved — separate from the pipeline's own approval gates, and the usual cause of "why am I being asked so much during implementation?". The same gap is behind two specific failures: a dispatched agent's ADR write under `context/adrs/` being denied, and the backend compile prompting because the implementer lacked build permission. The `setup-workspace-permissions.js` helper fixes all of these at once, but it is currently only offered in `/discover` — so surface it here too.
+
+First run a **non-writing** check to see whether this workspace already has a persistent allowlist (skip the whole step on `--resume`):
+
+```bash
+node {plugin_dir}/scripts/setup-workspace-permissions.js --config={workspace_root}/{slug}/config.json --dry-run
+```
+
+- If every target reports `+0 dirs, +0 allow rules` (already fully configured), print nothing — the allowlist is in place.
+- Otherwise (not set up, or missing rules) print this block once, then continue (do **NOT** block the pipeline on it):
 
 ```
-[tip] To cut Claude Code's per-tool-call approval prompts during implementation: press Shift+Tab → "accept edits", or add an allowlist (see {plugin_dir}/docs/permissions.md). This is separate from the pipeline's phase-boundary gates.
+[tip] Cut Claude Code's per-tool-call approval prompts during implementation (this is separate from the pipeline's phase-boundary gates):
+  • This run: press Shift+Tab → "accept edits", or re-run with --auto-approve.
+  • Persistently: run once, then restart claude —
+      node {plugin_dir}/scripts/setup-workspace-permissions.js --config={workspace_root}/{slug}/config.json
+    It writes a safe-only allowlist (file edits, read-only + local-only git, worktree
+    lifecycle, build/test for your stacks, and the Phase-6 chrome-devtools MCP) plus the
+    cross-repo additionalDirectories at your repos' shared parent — so cross-repo edits,
+    builds, the ADR write, and Phase-6 browser verification stop prompting. Destructive
+    commands (push, reset --hard, rm, deploys) still prompt. See {plugin_dir}/docs/permissions.md.
 ```
 
-Do not gate the pipeline on this; it is informational. Skip the line on `--resume` (the user has already seen it for this run).
+Note the settings file loads on the **next** `claude` launch, so it quiets future runs; for the current run, Shift+Tab / `--auto-approve` is the immediate lever. Do not gate the pipeline on any of this; it is informational.
 
 **Why checkpoints discipline matters for the UI:** the site-view derives the
 agent lifecycle (which agents ran, per-repo identity, tokens, duration,


### PR DESCRIPTION
## Problem

Several pain points from the test run reduce to **one root cause**: `setup-workspace-permissions.js` already grants the allowlist needed to stop the flood, but it was only offered in `/discover` — so a user who onboarded without it (or launches `/deliver` from a repo) keeps hitting:

- **E1** — per-tool-call approval prompts during implementation/review.
- **E7** — a dispatched agent's ADR write under `context/adrs/` denied (permission scope).
- **E9** — the backend compile prompting because the implementer lacked build permission (orchestrator then tried to compile itself).
- **E10** — the Phase-6 chrome-devtools browser-verification MCP prompting on every call.

## Changes

1. **Extend the helper's safe-only allowlist** (`scripts/setup-workspace-permissions.js`):
   - more build/test stacks: `gradle`, verb-scoped `go`/`cargo`/`dotnet` build+test, `poetry run`, `ruff`, `mypy`, `npx jest`/`prettier`;
   - the `git worktree` lifecycle the orchestrator drives + `git merge-base`;
   - the plugin's own zero-dep scripts;
   - the **`chrome-devtools`** MCP (`mcp__chrome-devtools__*`) for Phase-6 verification (server name matches `ensure-mcp.js`).
   - Install/publish subcommands (`go install`, `cargo install`/`publish`, `npm publish`, `dotnet nuget push`) stay omitted, so they keep prompting. Test extended to lock in both the new coverage and the safe-only invariant.

2. **Wire it into `/deliver` pre-flight** (`skills/deliver/phases/pre-flight.md`): runs the helper in `--dry-run`; if the workspace has no allowlist yet, prints the exact command to run once (settings load on next `claude` launch) plus the immediate levers for the current run (Shift+Tab / `--auto-approve`). Non-blocking.

3. `docs/permissions.md` updated to match (worktrees + chrome MCP in the allowlist; pre-flight now surfaces the helper).

## Tests
`setup-workspace-permissions.test.js`: 10 pass (incl. new coverage + safe-only invariant). Full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)