### PR TITLE
fix(discover): dedicated claude-only CLAUDE.md template + claude-only-aware validator

### DIFF
--- a/agents/context-manager.md
+++ b/agents/context-manager.md
@@ -126,11 +126,13 @@ Each row maps a task shape to the file(s) the agent must read FIRST. 4-7 rows ma
 **Process**:
 
 1. Deep-read the codebase — fewer files than `full` mode (4-6 representative sources).
-2. Write `CLAUDE.md` using the legacy template at `{plugin_dir}/templates/repo-CLAUDE.md.template`. Since there is no agent-context directory:
-   - The `## Deep context` table is omitted (no files to point to).
-   - The Agent guidelines section drops the mandatory bullets about `agent-context/AGENT_INDEX.md` and substitutes: "This repo is simple enough that all agent-facing guidance lives in this file." Keep the bullet about writing/updating tests.
+2. Write `CLAUDE.md` using the dedicated claude-only template at `{plugin_dir}/templates/repo-CLAUDE-claude-only.md.template`. It is purpose-built for this mode — no prose surgery required:
+   - It already carries the `<!-- claude-only-mode -->` sentinel on line 1 (do not remove it — the validator keys off it).
+   - It has **no** `## Deep context` table and **no** `AGENT_INDEX.md` / `agent-context/` bullets (a claude-only repo has neither); the Agent guidelines section is a self-contained note plus the keep-tests rule.
+   - Fill the placeholders (`{{REPO_NAME}}`, `{{REPO_PURPOSE}}`, `{{REPO_SPECIFIC_ABSOLUTES}}`, `{{QUICK_FACTS}}`, `{{BUILD_LANG}}`, `{{BUILD_COMMANDS}}`, `{{MUST_KNOW_GUIDELINES}}`).
    - Must-know guidelines can absorb up to the 10-bullet cap; anything over that is a signal this repo needs `full` mode instead — ask the orchestrator to re-dispatch.
-3. Validate with `validate-claude-md.js`. The validator skips the mandatory-bullet check if the file contains the explicit string `<!-- claude-only-mode -->` in the first 5 lines. Include that sentinel in the generated output.
+   - Do NOT introduce any `AGENT_INDEX` or `agent-context/` reference into the filled output — the validator hard-fails dangling references in claude-only mode (see step 3).
+3. Validate with `validate-claude-md.js`. Because the file carries `<!-- claude-only-mode -->` in its first 5 lines, the validator (a) **skips** the AGENT_INDEX/agent-context mandatory-bullet check and (b) **hard-fails** on any dangling `AGENT_INDEX` / `agent-context/` reference — so a self-contained file passes and one that still points at a non-existent index is caught. All other guardrails (coupling, absolute paths, size, must-know cap, secrets) still apply.
 
 **Hard constraints**: same as `full` mode (workspace-agnostic, no secrets, ≤150 lines, ≤10 must-knows).
 

--- a/scripts/validate-claude-md.js
+++ b/scripts/validate-claude-md.js
@@ -69,6 +69,12 @@ function validate(body, repoRoot) {
   const warnings = [];
   const lines = body.split(/\r?\n/);
 
+  // Claude-only mode: the repo has NO agent-context/ dir and NO AGENT_INDEX.md
+  // (sentinel emitted by context-manager's claude-only template, repo-CLAUDE-claude-only.md.template).
+  // In that mode the AGENT_INDEX / agent-context mandatory bullets do not apply, and
+  // any reference to those paths is a dead link by construction.
+  const claudeOnly = /<!--\s*claude-only-mode\s*-->/.test(lines.slice(0, 5).join('\n'));
+
   // 1. Coupling scan (hard-fail)
   for (const { pattern, label } of COUPLING_PATTERNS) {
     const m = body.match(pattern);
@@ -80,29 +86,49 @@ function validate(body, repoRoot) {
 
   // 2. Mandatory bullets present (hard-fail). Each bullet is a list of
   //    alternative regex patterns — match ANY one to satisfy the bullet.
-  for (let i = 0; i < MANDATORY_BULLETS.length; i++) {
-    const alternatives = MANDATORY_BULLETS[i];
-    const matched = alternatives.some(re => re.test(body));
-    if (!matched) {
-      errors.push(`mandatory-bullet: required preamble bullet ${i + 1} missing — must match one of ${alternatives.length} accepted phrasings (legacy or role-specific template)`);
+  //    Skipped in claude-only mode: those bullets point at AGENT_INDEX.md /
+  //    agent-context/, which a claude-only repo deliberately does not have.
+  if (!claudeOnly) {
+    for (let i = 0; i < MANDATORY_BULLETS.length; i++) {
+      const alternatives = MANDATORY_BULLETS[i];
+      const matched = alternatives.some(re => re.test(body));
+      if (!matched) {
+        errors.push(`mandatory-bullet: required preamble bullet ${i + 1} missing — must match one of ${alternatives.length} accepted phrasings (legacy or role-specific template)`);
+      }
     }
   }
 
-  // 3. Dead-link check (hard-fail)
-  //    Match `agent-context*/<path>` references inside backticks or markdown links.
-  const linkRegex = /`(agent-context[^`]*?\.md)`|\]\((agent-context[^)]*?\.md)\)/g;
-  const seen = new Set();
-  let linkMatch;
-  while ((linkMatch = linkRegex.exec(body)) !== null) {
-    const rel = linkMatch[1] || linkMatch[2];
-    if (seen.has(rel)) continue;
-    seen.add(rel);
-    // Skip glob / brace-expansion forms — they're doc shorthand, not exact paths.
-    if (rel.includes('*') || rel.includes('{')) continue;
-    const abs = path.join(repoRoot || '.', rel);
-    if (!fs.existsSync(abs)) {
-      const lineNo = lineOf(body, linkMatch.index);
-      errors.push(`dead-link: ${rel} at line ${lineNo} — file not found at ${abs}`);
+  // 3. Dead-link check (hard-fail).
+  if (!claudeOnly) {
+    //  Match `agent-context*/<path>` references inside backticks or markdown links.
+    const linkRegex = /`(agent-context[^`]*?\.md)`|\]\((agent-context[^)]*?\.md)\)/g;
+    const seen = new Set();
+    let linkMatch;
+    while ((linkMatch = linkRegex.exec(body)) !== null) {
+      const rel = linkMatch[1] || linkMatch[2];
+      if (seen.has(rel)) continue;
+      seen.add(rel);
+      // Skip glob / brace-expansion forms — they're doc shorthand, not exact paths.
+      if (rel.includes('*') || rel.includes('{')) continue;
+      const abs = path.join(repoRoot || '.', rel);
+      if (!fs.existsSync(abs)) {
+        const lineNo = lineOf(body, linkMatch.index);
+        errors.push(`dead-link: ${rel} at line ${lineNo} — file not found at ${abs}`);
+      }
+    }
+  } else {
+    // Claude-only: there is no agent-context/ dir or AGENT_INDEX.md, so ANY reference
+    // to them is broken by construction. This catches the forms the generic dead-link
+    // check above misses — e.g. `CLAUDE.md#AGENT_INDEX.md` and a bare `agent-context/`.
+    const danglingRe = /(AGENT_INDEX(?:\.md)?|agent-context\/?[A-Za-z0-9._/-]*)/g;
+    const seenDangling = new Set();
+    let dm;
+    while ((dm = danglingRe.exec(body)) !== null) {
+      const ref = dm[1];
+      if (seenDangling.has(ref)) continue;
+      seenDangling.add(ref);
+      const lineNo = lineOf(body, dm.index);
+      errors.push(`claude-only dangling-ref: "${ref}" at line ${lineNo} — this file is claude-only (no agent-context/ dir or AGENT_INDEX.md exists), so the reference is broken. Remove it, or switch the repo to full mode.`);
     }
   }
 

--- a/scripts/validate-claude-md.test.js
+++ b/scripts/validate-claude-md.test.js
@@ -217,6 +217,63 @@ test('7. secret scan — example.com / anthropic.com emails NOT flagged', () => 
   assert(!hasErr(r, 'email address'), 'false positive on example/anthropic email');
 });
 
+// ── claude-only mode (B5) ──────────────────────────────────────────────
+const claudeOnlyBody = [
+  '<!-- claude-only-mode -->',
+  '# tiny-repo',
+  '',
+  'One-line purpose.',
+  '',
+  '## Agent guidelines',
+  '',
+  '- This repo is simple enough that all agent-facing guidance lives in this file.',
+  '- Write or update tests for every change; all tests must pass before a change is considered done.',
+  '',
+  '## Quick facts',
+  '- Stack: Node',
+  '',
+  '## Build & run',
+  '```bash',
+  'npm install',
+  '```',
+  '',
+  '## Must-know guidelines (repo-specific)',
+  '',
+  '1. Rule A',
+  ''
+].join('\n');
+
+test('claude-only — self-contained file passes (no mandatory-bullet failure)', () => {
+  const r = validate(claudeOnlyBody, tmpRepo);
+  assert(r.errors.length === 0, `unexpected errors: ${r.errors.join('; ')}`);
+  assert(!hasErr(r, 'mandatory-bullet'), 'claude-only must skip the mandatory-bullet check');
+});
+
+test('claude-only — dangling AGENT_INDEX anchor is a hard-fail', () => {
+  const body = claudeOnlyBody.replace(
+    '- This repo is simple enough that all agent-facing guidance lives in this file.',
+    '- Read `CLAUDE.md#AGENT_INDEX.md` — it maps tasks to docs.'
+  );
+  const r = validate(body, tmpRepo);
+  assert(hasErr(r, 'claude-only dangling-ref'), 'missed dangling AGENT_INDEX reference');
+  assert(hasErr(r, 'AGENT_INDEX'), 'error should name the broken ref');
+});
+
+test('claude-only — bare agent-context/ reference is a hard-fail', () => {
+  const body = claudeOnlyBody.replace(
+    '- Write or update tests for every change; all tests must pass before a change is considered done.',
+    '- Update the matching file under `agent-context/` in the same change.\n- Write or update tests for every change; all tests must pass before a change is considered done.'
+  );
+  const r = validate(body, tmpRepo);
+  assert(hasErr(r, 'claude-only dangling-ref'), 'missed dangling agent-context/ reference');
+});
+
+test('claude-only — still enforces coupling/secret scans', () => {
+  const body = claudeOnlyBody + '\nkey: AKIAIOSFODNN7EXAMPLE\n';
+  const r = validate(body, tmpRepo);
+  assert(hasErr(r, 'AWS access key'), 'claude-only must still run the secret scan');
+});
+
 test('10. idempotency — "Last Updated: YYYY-MM-DD" trailer warns', () => {
   const body = validBody + '\n---\n\n*Last Updated: 2026-04-15*\n';
   const r = validate(body, tmpRepo);

--- a/templates/repo-CLAUDE-claude-only.md.template
+++ b/templates/repo-CLAUDE-claude-only.md.template
@@ -1,0 +1,26 @@
+<!-- claude-only-mode -->
+# {{REPO_NAME}}
+
+{{REPO_PURPOSE}}
+
+## Agent guidelines
+
+- This repo is simple enough that all agent-facing guidance lives in this file — there is no separate deep-context directory to consult or keep in sync.
+- Write or update tests for every change; all tests must pass before a change is considered done.
+{{REPO_SPECIFIC_ABSOLUTES}}
+
+## Quick facts
+
+<!-- One concept per bullet. Group by dimension (Language/build · Data · Integrations · Testing · Tooling · …). Don't emit a single paragraph-style bullet. Strip this comment before writing. -->
+{{QUICK_FACTS}}
+
+## Build & run
+
+```{{BUILD_LANG}}
+{{BUILD_COMMANDS}}
+```
+
+## Must-know guidelines (repo-specific)
+
+<!-- Max 10 bullets (validator enforces). Each bullet ≤ one line. One concept per bullet — split "fact + rule" into two bullets if they mix. If you need more than 10, this repo wants full mode instead. Strip this comment before writing. -->
+{{MUST_KNOW_GUIDELINES}}


### PR DESCRIPTION
## Problem (B5)

Claude-only repos (no `agent-context/` dir — `mock-server`/`infrastructure`/`contract`/`other` roles, or small repos) were generated from the legacy `repo-CLAUDE.md.template` via fragile prose surgery, leaving **dangling references** like `CLAUDE.md#AGENT_INDEX.md` and a bare `agent-context/` that point at files which don't exist. Three-part cause:

1. No dedicated claude-only template — it reused the AGENT_INDEX-laden legacy one.
2. `validate-claude-md.js` *forced* an AGENT_INDEX-shaped mandatory bullet (so the generator kept one and just repointed it), and its dead-link check only matched `agent-context*.md` — so `#AGENT_INDEX.md` and bare `agent-context/` slipped through.
3. `context-manager.md` claimed the validator skips the mandatory-bullet check on the `<!-- claude-only-mode -->` sentinel — **it didn't**.

## Fixes

- **New `templates/repo-CLAUDE-claude-only.md.template`** — sentinel on line 1, no Deep-context table, no AGENT_INDEX/agent-context bullets; self-contained.
- **`validate-claude-md.js` is now claude-only-aware**: on the sentinel it (a) **skips** the AGENT_INDEX/agent-context mandatory-bullet check and (b) **hard-fails** any dangling `AGENT_INDEX` / `agent-context/` reference (catching the forms the generic dead-link check missed). Coupling / absolute-path / size / must-know-cap / secret scans still apply.
- **`context-manager.md` Mode: claude-only** now uses the new template, and its step-3 description of the validator is finally accurate.

## Tests
`validate-claude-md.test.js`: 26 pass (4 new claude-only cases — self-contained passes, dangling `#AGENT_INDEX.md` fails, bare `agent-context/` fails, secret scan still runs). Full eval suite green (the new template parses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)