### PR TITLE
fix(site-view): surface more notifications, fix voice-on-enable race, relabel B3 agent

### DIFF
--- a/scripts/notify-hook.js
+++ b/scripts/notify-hook.js
@@ -169,21 +169,31 @@ function onNotification() {
       payload = { message: raw.slice(0, 400) };
     }
   }
-  // Claude Code fires Notification for several reasons. We only care about the
-  // "waiting for permission" variant. The message text is the most reliable
-  // signal; fall back to always-write if we can't tell (better false-positive
-  // than miss the real case).
+  // Claude Code fires Notification whenever it needs the user to act — both
+  // permission prompts AND idle "waiting for your input" notices. Surface a
+  // banner for any of those. The previous filter matched only four keywords and
+  // SKIPPED everything else, so any message phrased differently was silently
+  // dropped — the cause of "Claude Code notifications not reflected in the view".
+  // Honor the documented intent ("better a false positive than miss the real
+  // case"): write the flag unless the message is clearly *informational*.
   const msg = payload && payload.message ? String(payload.message).toLowerCase() : '';
-  const isPermissionPrompt =
-    msg.includes('permission') ||
-    msg.includes('approval') ||
-    msg.includes('waiting for') ||
-    msg.includes('needs your');
+  const WAIT_HINTS = [
+    'permission', 'approval', 'approve', 'waiting for', 'is waiting',
+    'needs your', 'needs you', 'requires your', 'your input', 'your response',
+    'your attention', 'awaiting', 'idle', 'confirm', 'respond', 'review',
+  ];
+  const INFORMATIONAL_HINTS = [
+    'completed', 'finished', 'succeeded', 'success', ' done', 'all set',
+  ];
+  const looksWaiting = WAIT_HINTS.some((h) => msg.includes(h));
+  const looksInformational = INFORMATIONAL_HINTS.some((h) => msg.includes(h));
 
-  // If we can't decide, default to writing the flag — the UI will clear it as
-  // soon as the user responds (UserPromptSubmit / PostToolUse hooks below).
-  if (msg && !isPermissionPrompt) {
-    debug(`skip non-permission notification: ${msg.slice(0, 80)}`);
+  // Skip only when the message is present, clearly informational, and NOT a wait.
+  // Empty/unrecognized messages fall through to writing the flag — the UI clears
+  // it the moment the user responds (UserPromptSubmit / PostToolUse below), so a
+  // transient false banner is cheap; a missed wait is not.
+  if (msg && looksInformational && !looksWaiting) {
+    debug(`skip informational notification: ${msg.slice(0, 80)}`);
     return;
   }
 

--- a/skills/discover/phases/phase-d-verification.md
+++ b/skills/discover/phases/phase-d-verification.md
@@ -183,7 +183,7 @@ Per-agent detail:
 | Agent                       | Phase | Tokens   | Duration | Status   | Findings |
 |-----------------------------|-------|----------|----------|----------|----------|
 | solution-architect          | B2    |  77,922  | 4:03     | ok       | —        |
-| general-purpose (design-sys)| B3    |  46,687  | 2:16     | ok       | —        |
+| ux-consultant (discovery)   | B3    |  46,687  | 2:16     | ok       | —        |
 | context-manager:full (auth)      | C2 |  48,702  | 3:12     | ok       | 2        |
 | context-manager:full (publisher) | C2 |  71,521  | 4:05     | ok       | 5        |
 | context-manager:full (backoffice) | C2 | 38,400  | 2:45     | retry→ok | 1        |

--- a/skills/site-view/public/index.html
+++ b/skills/site-view/public/index.html
@@ -2279,8 +2279,12 @@ function enableSound() {
   // autoplay gate and unlocks the context for subsequent playBeep() calls.
   playBeep();
   syncSoundPills();
-  // If we're already paused, kick off the peeping loop immediately.
-  if (currentPaused) startBeeping();
+  // Kick off the peeping loop immediately if a gate is active right now. Check
+  // the live banner state (activeGateSince) in addition to currentPaused: the
+  // user often clicks "enable sound" in the window between a gate appearing and
+  // the next applyState() that flips currentPaused — which is why sound used to
+  // start only after a manual mute/unmute cycle. startBeeping() is idempotent.
+  if (currentPaused || activeGateSince()) startBeeping();
 }
 
 function syncSoundPills() {


### PR DESCRIPTION
## WS10 — site-view polish (3 self-contained fixes)

**F1 — notifications not reflected.** `notify-hook.js` matched only four keywords (`permission`/`approval`/`waiting for`/`needs your`) and **skipped every other message**, so Claude Code notifications phrased differently never produced a banner. It now writes the approval flag for any wait-like notification (expanded hint list) and skips only clearly *informational* ones (completed/finished/succeeded/…), honoring the file's own documented intent ("better a false positive than miss the real case").

**F4 — voice only after mute/unmute.** `enableSound()` started the beep loop only `if (currentPaused)`, which lags the live banner state — so audio began only after a manual mute→unmute cycle. It now also checks the live `activeGateSince()`; `startBeeping()` is idempotent so the extra call is safe.

**A9 — B3 agent mislabeled.** The Phase D reporter example labeled the design-system agent `general-purpose (design-sys)`; B3 dispatches the `ux-consultant` in discovery mode, so the example row now reads `ux-consultant (discovery)`. (With `agent_start` now emitting `agent_type`, the live view labels it correctly too.)

## Deferred to follow-ups (same WS10 cluster)
- **F8** — `gate_open`/`gate_close` checkpoint events + a poll fallback for the gate flag files (a schema addition like the `agent_start` change; its own PR).
- **F5/F7** — robust repo extraction in `server.js` (`repoHintFromDescription`) so per-repo implementers/reviewers stop collapsing into one "cross-repo" card; deserves its own change + tests.

## Tests
`node -c` clean on the hook; full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)