### PR TITLE
feat(discover): dedicated agent-context bundle for infrastructure repos

### DIFF
--- a/agents/context-manager.md
+++ b/agents/context-manager.md
@@ -48,11 +48,13 @@ The template bundle you use depends on the repo's role from `config.repos[*].rol
 | `worker` | `templates/agent-context-backend/` | `templates/repo-CLAUDE-backend.md.template` |
 | `frontend` | `templates/agent-context-frontend/` | `templates/repo-CLAUDE-frontend.md.template` |
 | `mock-server` | (none — fall back to `claude-only` mode) | `templates/repo-CLAUDE.md.template` |
-| `infrastructure` | (none — fall back to `claude-only` mode) | `templates/repo-CLAUDE.md.template` |
+| `infrastructure` | `templates/agent-context-infra/` | `templates/repo-CLAUDE-infra.md.template` |
 | `contract` | (none — fall back to `claude-only` mode) | `templates/repo-CLAUDE.md.template` |
 | `other` | (none — fall back to `claude-only` mode) | `templates/repo-CLAUDE.md.template` |
 
 If the role doesn't have a dedicated bundle, downgrade to `claude-only` mode automatically and inform the orchestrator. Don't try to force a generic agent-context structure on a role that doesn't fit.
+
+The `agent-context-infra/` bundle is **top-level files only** — it has no `domains/` / `integrations/` plural subfolders, so Step 4's per-bounded-context / per-integration sub-file step simply doesn't apply when generating for an `infrastructure` repo (fill the top-level `*.md.template` files and stop).
 
 ---
 
@@ -78,7 +80,7 @@ If the role doesn't have a dedicated bundle, downgrade to `claude-only` mode aut
    - For each external system the repo integrates with (cloud provider, message broker, third-party SaaS), copy the equivalent template (`integrations/_template.md` for backend, or the frontend equivalent), rename, and fill.
    - **Preserve marker comments verbatim** — agents downstream rely on them being present and well-formed (matching open/close pairs).
 
-5. **Write `CLAUDE.md`** using the role-specific template (`templates/repo-CLAUDE-backend.md.template` or `templates/repo-CLAUDE-frontend.md.template`). Fill placeholders with the authoritative facts you've already written to agent-context — CLAUDE.md is the always-loaded entry point, sized at ~50 lines, and contains:
+5. **Write `CLAUDE.md`** using the role-specific template (`templates/repo-CLAUDE-backend.md.template`, `templates/repo-CLAUDE-frontend.md.template`, or `templates/repo-CLAUDE-infra.md.template`). Fill placeholders with the authoritative facts you've already written to agent-context — CLAUDE.md is the always-loaded entry point, sized at ~50 lines, and contains:
    - Identity (name, tagline, 1-2 sentence purpose)
    - Workflow ritual ("Before You Plan a Change", placed at the top right after the purpose so agents see it first: read AGENT_INDEX, follow the decision table, follow conventions, update agent-context only for new things, write/update tests for every change)
    - Decision table (4-7 rows mapping common task shapes to specific agent-context files)
@@ -119,7 +121,7 @@ Each row maps a task shape to the file(s) the agent must read FIRST. 4-7 rows ma
 
 ### Mode: claude-only
 
-**When**: during `/discover` Phase C, for repos where the user chose "(b) CLAUDE.md only — lighter, self-contained, no subdirectory". For small/simple repos OR for repo roles that have no dedicated template bundle (`mock-server`, `infrastructure`, `contract`, `other`).
+**When**: during `/discover` Phase C, for repos where the user chose "(b) CLAUDE.md only — lighter, self-contained, no subdirectory". For small/simple repos OR for repo roles that have no dedicated template bundle (`mock-server`, `contract`, `other`). Note: `infrastructure` now has its own bundle (`agent-context-infra/`) and defaults to `full` mode — it only lands here if the user explicitly picks "(b) CLAUDE.md only" for a trivial IaC repo.
 
 **Input**: repo path, repo type, repo role, optional repo-specific absolute facts.
 

--- a/skills/discover/phases/phase-c-generation.md
+++ b/skills/discover/phases/phase-c-generation.md
@@ -103,7 +103,8 @@ Read {repo_path}/CLAUDE.md if it exists, and any existing agent-context/ directo
 Template dispatch (per your system prompt):
 - role = api-service OR worker → use templates/agent-context-backend/ + templates/repo-CLAUDE-backend.md.template
 - role = frontend             → use templates/agent-context-frontend/ + templates/repo-CLAUDE-frontend.md.template
-- role = mock-server / infrastructure / contract / other → downgrade to claude-only mode (use templates/repo-CLAUDE.md.template)
+- role = infrastructure       → use templates/agent-context-infra/ + templates/repo-CLAUDE-infra.md.template (top-level files only — no domains/ or integrations/ subfolders)
+- role = mock-server / contract / other → downgrade to claude-only mode (use templates/repo-CLAUDE.md.template)
 
 Output order:
 1. agent-context/ first — fill every *.md.template in the chosen bundle (AGENT_INDEX, business-context, architecture, conventions, plus role-specific singletons). Strip the <!-- AGENT INSTRUCTIONS --> blocks. Preserve <!-- agent-updatable --> / <!-- human-owned --> markers verbatim.

--- a/templates/agent-context-infra/AGENT_INDEX.md.template
+++ b/templates/agent-context-infra/AGENT_INDEX.md.template
@@ -1,0 +1,90 @@
+# Agent Index — {{REPO_NAME}}
+
+This file is the router for all agent-facing context in this infrastructure /
+IaC repo. Stable rules and the quick start live in the root `CLAUDE.md`. Detail
+lives in the files below.
+
+---
+
+## Section Markers (read this once)
+
+Inside every doc, sections are marked for who owns them:
+
+- `<!-- agent-updatable -->` ... `<!-- /agent-updatable -->`
+  Catalogs and inventories of things that exist (the stack list, the resource
+  table, IAM role table). Add a row when you add a new stack/resource/role.
+  Do not rewrite existing rows for routine changes.
+
+- `<!-- human-owned -->` ... `<!-- /human-owned -->`
+  Conventions, patterns, "What NOT to Do" sections. Agents must read these and
+  follow them. **Never edit human-owned sections.** Surface a needed change; the
+  human decides.
+
+Anything unmarked defaults to **human-owned**.
+
+### When you think a human-owned section needs to change
+
+- **Confused** — the rule is unclear. → Ask before acting.
+- **Outdated** — the rule no longer matches what the code does. → Flag it with
+  file:line evidence, propose the new wording, wait for the human.
+- **In conflict** — your task seems to require violating the rule. → Stop and
+  surface the conflict.
+
+The agent surfaces, the human decides. Never silently edit a human-owned
+section, never silently violate a convention.
+
+---
+
+## Directory Tree (agent-context/)
+
+```
+agent-context/
+├── AGENT_INDEX.md         <- this file
+├── business-context.md    <- what this repo provisions for the platform, and why
+├── stacks.md              <- the stacks / modules and what each one owns
+├── resources.md           <- catalog of provisioned resources + naming patterns
+├── iam.md                 <- roles, policies, least-privilege + cross-stack refs
+├── stage-region.md        <- stage / env / region handling + naming conventions
+├── deployment.md          <- synth / diff / deploy flow, bootstrap, approvals
+└── conventions.md         <- IaC code conventions, tagging, removal policies
+```
+
+---
+
+## Topic → File Mapping
+
+{{TOPIC_FILE_MAPPING}}
+
+---
+
+## Boundary Rules (where new content goes)
+
+- **`stacks.md`** — the authoritative list of stacks/modules and the resources
+  each owns. Add a row when you add a stack. If one stack grows a genuinely
+  complex sub-domain, note it inline — this repo does not use plural subfolders.
+- **`resources.md`** — the catalog of concrete provisioned resources (buckets,
+  queues, tables, functions, distributions) with their naming pattern per stage.
+  This is the `<!-- agent-updatable -->` inventory; keep it current.
+- **`iam.md`** — every role/policy and the least-privilege reasoning, plus the
+  cross-stack / cross-account references other workspaces or repos consume.
+- **`conventions.md`** ends with a `## What NOT to Do` section listing real
+  footguns in the existing code that agents must not copy.
+
+<!--
+AGENT INSTRUCTIONS (strip these comments before writing the final file):
+
+- {{REPO_NAME}}: short repo name (e.g., "abvi-infra").
+- {{TOPIC_FILE_MAPPING}}: a markdown table mapping common topics to the file
+  that owns them. Adapt the file list above to what was actually generated.
+  Example rows:
+  | Topic | File |
+  |---|---|
+  | What this repo provisions, for whom | `business-context.md` |
+  | Which stack owns a resource | `stacks.md` |
+  | A bucket / queue / table / function name + pattern | `resources.md` |
+  | An IAM role / policy / cross-stack export | `iam.md` |
+  | Stage / region / env naming + per-env config | `stage-region.md` |
+  | How to synth / diff / deploy / bootstrap | `deployment.md` |
+  | Construct patterns, tagging, removalPolicy | `conventions.md` |
+- Drop rows for files you didn't generate.
+-->

--- a/templates/agent-context-infra/business-context.md.template
+++ b/templates/agent-context-infra/business-context.md.template
@@ -1,0 +1,17 @@
+# Business Context — {{REPO_NAME}}
+
+Product framing only — what this infrastructure repo provisions for the
+platform and why it exists. No construct code, no resource tables (those live in
+`stacks.md` / `resources.md`).
+
+{{BUSINESS_CONTEXT}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{BUSINESS_CONTEXT}}: 1-3 short paragraphs. What does this repo stand up for
+  the rest of the platform (the shared buckets/queues/networking/compute other
+  services depend on)? Who operates it? What's the blast radius — i.e. which
+  services break if this is misconfigured? Keep it to framing an agent needs
+  before touching the infra; no inventory.
+-->

--- a/templates/agent-context-infra/conventions.md.template
+++ b/templates/agent-context-infra/conventions.md.template
@@ -1,0 +1,41 @@
+# Conventions — {{REPO_NAME}}
+
+How IaC code is written here. Follow what exists; don't introduce a second way
+of doing something that already has one.
+
+## Construct / module patterns
+
+<!-- human-owned -->
+
+{{CONSTRUCT_PATTERNS}}
+
+<!-- /human-owned -->
+
+## Tagging & naming
+
+{{TAGGING_AND_NAMING}}
+
+## What NOT to Do
+
+<!-- human-owned -->
+
+{{WHAT_NOT_TO_DO}}
+
+<!-- /human-owned -->
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{CONSTRUCT_PATTERNS}}: how resources are organized — L2/L3 constructs vs raw
+  Cfn, reusable construct/module dirs, where shared config lives, prop interfaces
+  vs positional args. Cite a representative file (file:line).
+- {{TAGGING_AND_NAMING}}: the mandatory tag set (and the helper that applies it),
+  the name-builder convention (cross-ref `resources.md`), and stack-naming.
+- {{WHAT_NOT_TO_DO}}: the silent-damage footguns specific to THIS repo. Each must
+  pass: (1) violating it does NOT fail synth/plan/lint, (2) applies broadly,
+  (3) not obvious from nearby code. Examples that qualify: "never set
+  `removalPolicy: DESTROY` on a stateful resource in prod", "never hardcode an
+  account ID — derive from the stage map", "never widen an IAM action to `*`",
+  "never rename a stack export consumed cross-stack without a migration". Drop
+  generic style rules — those are not silent-damage.
+-->

--- a/templates/agent-context-infra/deployment.md.template
+++ b/templates/agent-context-infra/deployment.md.template
@@ -1,0 +1,36 @@
+# Deployment — {{REPO_NAME}}
+
+How changes in this repo reach a real environment. Agents implementing infra
+changes produce a **plan/diff artifact for a human to review** — they never
+apply to a live environment themselves.
+
+## Synth / plan / diff
+
+{{SYNTH_PLAN_DIFF}}
+
+## Deploy & bootstrap
+
+<!-- human-owned -->
+
+{{DEPLOY_AND_BOOTSTRAP}}
+
+<!-- /human-owned -->
+
+## Verification artifact
+
+{{VERIFICATION_ARTIFACT}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{SYNTH_PLAN_DIFF}}: the exact commands to render the change without applying
+  it (`cdk synth`, `cdk diff`, `terraform plan`, `sls package`), incl. how to
+  scope to one stack and how to pass the stage. This is what an implementer runs.
+- {{DEPLOY_AND_BOOTSTRAP}}: how a human actually deploys (pipeline vs manual
+  `cdk deploy` / `terraform apply`), any one-time bootstrap (`cdk bootstrap`,
+  TF backend/state, remote-state locking), and approval gates. **Note that
+  agents must NOT run apply/deploy/destroy** — the plan/diff is the deliverable.
+- {{VERIFICATION_ARTIFACT}}: what a reviewer reads to verify a change — the
+  `cdk diff` / `terraform plan` output (and where it lands). Note that `cdk
+  synth` failing = the implementer reported a failed verification.
+-->

--- a/templates/agent-context-infra/iam.md.template
+++ b/templates/agent-context-infra/iam.md.template
@@ -1,0 +1,43 @@
+# IAM & Cross-Stack References — {{REPO_NAME}}
+
+Who can do what, and which resources this repo exports for other stacks /
+repos / workspaces to consume. Getting an IAM grant wrong is the classic
+silent infra bug — too broad ships a security hole, too narrow fails only at
+runtime in the target environment.
+
+## IAM roles & policies
+
+<!-- agent-updatable -->
+
+{{IAM_CATALOG}}
+
+<!-- /agent-updatable -->
+
+## Least-privilege patterns
+
+<!-- human-owned -->
+
+{{LEAST_PRIVILEGE_PATTERNS}}
+
+<!-- /human-owned -->
+
+## Cross-stack / cross-account references
+
+{{CROSS_STACK_REFS}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{IAM_CATALOG}}: a markdown table of roles/policies. Columns:
+  Role/Policy | Granted to | Allows (actions on resources) | Defined in.
+  Agent-updatable inventory.
+- {{LEAST_PRIVILEGE_PATTERNS}}: how the repo scopes grants (e.g. "use
+  `bucket.grantRead(fn)` / `queue.grantConsumeMessages(fn)` helpers, never a
+  raw `*` action or `Resource: *`"). Name the helper/module. Call out any
+  observed over-broad grant as an audit finding (file:line).
+- {{CROSS_STACK_REFS}}: what this repo EXPORTS (CloudFormation outputs / SSM
+  params / Terraform outputs / `Fn::ImportValue` keys) and what it IMPORTS from
+  elsewhere — the contract other stacks/repos depend on. Renaming or removing an
+  export is a breaking change; note that explicitly. "None" if the repo is
+  self-contained.
+-->

--- a/templates/agent-context-infra/resources.md.template
+++ b/templates/agent-context-infra/resources.md.template
@@ -1,0 +1,43 @@
+# Resources — {{REPO_NAME}}
+
+The concrete cloud resources this repo provisions, and the **naming pattern**
+each follows per stage. Agents adding a resource must match the existing pattern
+— a name that doesn't follow the convention silently breaks cross-stack lookups
+and the troubleshooter's log routing.
+
+## Naming convention
+
+<!-- human-owned -->
+
+{{NAMING_CONVENTION}}
+
+<!-- /human-owned -->
+
+## Resource catalog
+
+<!-- agent-updatable -->
+
+{{RESOURCE_CATALOG}}
+
+<!-- /agent-updatable -->
+
+## Encryption, retention & removal defaults
+
+{{RESOURCE_DEFAULTS}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{NAMING_CONVENTION}}: the literal naming pattern resources follow, with the
+  stage/region tokens spelled out (e.g. "`{service}-{resource}-{stage}` plus a
+  region suffix for replicated buckets: `abvi-books-{stage}{regionSuffix}`").
+  Quote the helper/construct that builds names if there is one (file:line).
+- {{RESOURCE_CATALOG}}: a markdown table of provisioned resources. Columns:
+  Resource | Type | Name pattern | Stack | Purpose. Group by type (buckets,
+  queues/topics, tables, functions, distributions, secrets). The agent-updatable
+  inventory — add a row per new resource.
+- {{RESOURCE_DEFAULTS}}: the defaults the repo applies (or fails to) — encryption
+  at rest, versioning, `removalPolicy`/`prevent_destroy`, log retention, DLQ
+  wiring. Note any resource that diverges from the default and why. Flag a
+  missing-encryption or `RETAIN`-missing-on-prod as an audit finding.
+-->

--- a/templates/agent-context-infra/stacks.md.template
+++ b/templates/agent-context-infra/stacks.md.template
@@ -1,0 +1,35 @@
+# Stacks — {{REPO_NAME}}
+
+How this repo is decomposed into stacks / modules, what each one owns, and the
+dependency order between them.
+
+## Framework
+
+{{IAC_FRAMEWORK}}
+
+## Stack catalog
+
+<!-- agent-updatable -->
+
+{{STACK_CATALOG}}
+
+<!-- /agent-updatable -->
+
+## Dependencies & deploy order
+
+{{STACK_DEPENDENCIES}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{IAC_FRAMEWORK}}: the IaC tool + version + language (e.g. "AWS CDK v2
+  (TypeScript), Node 20" / "Terraform 1.7, AWS provider 5.x" / "Serverless
+  Framework 3"). Name the entrypoint (e.g. `bin/app.ts`, root `main.tf`).
+- {{STACK_CATALOG}}: a markdown table of every stack/module. Columns:
+  Stack | Source path | Owns (key resources) | Notes. One row per stack.
+  This is the agent-updatable inventory — add a row when a stack is added.
+- {{STACK_DEPENDENCIES}}: the dependency/deploy order and why (e.g. "network →
+  data → compute → edge; the data stack exports the table ARN the compute stack
+  imports"). Note any explicit `addDependency` / `depends_on` wiring and any
+  cross-stack export/import (detail lives in iam.md / resources.md).
+-->

--- a/templates/agent-context-infra/stage-region.md.template
+++ b/templates/agent-context-infra/stage-region.md.template
@@ -1,0 +1,36 @@
+# Stages, Environments & Regions — {{REPO_NAME}}
+
+How this repo parameterizes per environment. Every resource name, account, and
+config value flows from here — an agent that hardcodes a value that should be
+stage-derived breaks the next environment silently.
+
+## Stages & accounts
+
+<!-- human-owned -->
+
+{{STAGES_AND_ACCOUNTS}}
+
+<!-- /human-owned -->
+
+## Region handling
+
+{{REGION_HANDLING}}
+
+## Per-environment configuration
+
+{{PER_ENV_CONFIG}}
+
+<!--
+AGENT INSTRUCTIONS (strip before writing):
+
+- {{STAGES_AND_ACCOUNTS}}: the stages this repo deploys (dev / staging / prod /
+  …), how the stage is selected (context var, `--context stage=`, workspace,
+  TF var, env var), and the account mapping if multi-account. Quote the helper
+  that resolves the current stage (file:line).
+- {{REGION_HANDLING}}: single vs multi-region; how the region (and any
+  `regionSuffix` used in names) is derived; which resources are replicated.
+- {{PER_ENV_CONFIG}}: where per-env values live (a `config/{stage}.ts`, a
+  `tfvars` file, SSM, etc.) and the rule for adding a new tunable — point at the
+  config source rather than restating every value. Note any value that MUST
+  differ per env (sizes, retention, removal policy, log levels).
+-->

--- a/templates/repo-CLAUDE-infra.md.template
+++ b/templates/repo-CLAUDE-infra.md.template
@@ -1,0 +1,71 @@
+# CLAUDE.md — {{REPO_NAME}}
+
+{{REPO_TAGLINE}}
+
+{{REPO_PURPOSE_PARAGRAPH}}
+
+## Before You Plan a Change
+
+1. Read `agent-context/AGENT_INDEX.md` — it maps tasks to docs.
+2. For common changes, the required reading is:
+
+{{DECISION_TABLE}}
+
+3. **Follow the conventions you find. Do not invent or "improve" them.**
+   If a convention is unclear, seems to conflict with existing code, or appears
+   outdated based on what you observe — stop, surface the issue, and propose
+   the change. Do NOT edit human-owned sections yourself.
+
+4. Update `agent-context/` ONLY when you added something new to the world:
+   a new stack, resource, IAM role, cross-stack export, or per-env tunable —
+   OR when you discovered a non-obvious invariant the next agent would miss.
+   Edits go in sections marked `<!-- agent-updatable -->`. Do NOT modify
+   sections marked `<!-- human-owned -->`. The git log is the changelog,
+   not these docs.
+
+5. Produce a plan/diff for review — never apply to a live environment. Run the
+   synth/plan/diff commands; an apply/deploy/destroy is a human action.
+
+## Quick Start
+
+```{{BUILD_LANG}}
+{{QUICK_START_COMMANDS}}
+```
+
+## Inviolable Rules
+
+These cause silent damage — synth/plan/lint will not catch them.
+
+{{INVIOLABLE_RULES}}
+
+<!--
+AGENT INSTRUCTIONS (strip these comments before writing the final file):
+
+- {{REPO_NAME}}: short repo name (e.g., "abvi-infra").
+- {{REPO_TAGLINE}}: one-line stack + role (e.g., "AWS CDK v2 / TypeScript
+  infrastructure for the Arabookverse platform.").
+- {{REPO_PURPOSE_PARAGRAPH}}: 1-2 sentences naming what this repo provisions and
+  its blast radius (which services depend on it).
+- {{BUILD_LANG}}: code-fence language for quick start (`bash`, `powershell`).
+- {{QUICK_START_COMMANDS}}: minimum viable commands — typically deps + synth +
+  diff (NOT deploy). 3-5 lines, no explanation.
+- {{DECISION_TABLE}}: a markdown table, columns "About to..." and "Read first".
+  4-7 rows for THIS repo's common change types. Examples (include if applicable):
+  | About to... | Read first |
+  |---|---|
+  | Add/modify a stack | `stacks.md`, `conventions.md` |
+  | Add a bucket/queue/table/function | `resources.md`, `conventions.md` |
+  | Grant or change an IAM permission | `iam.md` |
+  | Touch stage/region/env config | `stage-region.md` |
+  | Deploy / bootstrap / read a diff | `deployment.md` |
+- {{INVIOLABLE_RULES}}: a numbered list of 4-7 rules. EACH must pass all three:
+  (1) violating it causes SILENT damage (no synth/plan/lint failure), (2) applies
+  broadly, (3) not obvious from nearby code. Examples that pass: "never set
+  removalPolicy DESTROY on a stateful prod resource", "never hardcode an account
+  ID — derive from the stage map", "never widen an IAM action to *", "never
+  rename a cross-stack export without a migration". Style rules belong in
+  conventions.md, not here.
+
+Total file: aim for ≤60 lines after stripping these comments. Hard ceiling
+(validator-enforced): 200 lines.
+-->


### PR DESCRIPTION
## Problem (A10)

Infrastructure / IaC repos (CDK, Terraform, Serverless) had **no template bundle**, so `context-manager` downgraded them to `claude-only` — a single CLAUDE.md with no structured context. That under-serves real infra repos: many stacks, multi-region/stage handling, shared IAM, cross-stack exports, removal-policy invariants. (The backend bundle even ships an unused `infrastructure.md.template`, underscoring the gap.)

## Change

New **`templates/agent-context-infra/`** bundle (top-level files only — no `domains/` / `integrations/` subfolders, which don't fit IaC):
- `AGENT_INDEX`, `business-context`, `stacks`, `resources`, `iam`, `stage-region`, `deployment`, `conventions`

plus **`templates/repo-CLAUDE-infra.md.template`** — the thin always-loaded index, emphasizing *"produce a plan/diff for review, never apply"*.

**Wiring:**
- `context-manager.md` role dispatch maps `infrastructure` → the infra bundle + infra CLAUDE template (full mode), and notes the bundle is top-level-only so Step 4's per-context/per-integration sub-file step is skipped for infra.
- `phase-c-generation.md` template dispatch updated to match; `infrastructure` removed from the claude-only downgrade list (`mock-server`/`contract`/`other` stay).

Templates use the same placeholder + AGENT-INSTRUCTIONS + `agent-updatable`/`human-owned` marker conventions as the backend/frontend bundles, so the existing `context-manager` fill logic handles them unchanged.

## Tests
Full eval suite green (templates parse; refs resolve). No script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)