### PR TITLE
feat(observability): record approval gates as gate_open/gate_close checkpoints

### DIFF
--- a/rules/observability.md
+++ b/rules/observability.md
@@ -60,7 +60,7 @@ Every line in `checkpoints.jsonl` is one JSON event on its own line. Append-only
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `ts` | ISO8601 UTC | always | Emission time (e.g., `"2026-04-15T14:27:44Z"`) |
-| `event` | enum | always | One of the 9 event types below |
+| `event` | enum | always | One of the 11 event types below |
 | `skill` | enum | always | `"discover" \| "deliver" \| "learn" \| "review" \| "assess" \| "context-refresh"` |
 | | | | Legacy runs may carry the pre-rename values `"onboard"` / `"feature"`; the validator accepts both for backcompat. |
 | `run_id` | string | always | Matches the directory name |
@@ -69,7 +69,7 @@ Every line in `checkpoints.jsonl` is one JSON event on its own line. Append-only
 
 Fields that have no source data → **omit the key entirely**. Do not fabricate zero values. The validator rejects fabricated `0` for fields the caller couldn't have measured.
 
-### Event types — the 9 canonical events
+### Event types — the 11 canonical events
 
 #### `run_start` — first line of every log
 
@@ -236,6 +236,36 @@ Required: `duration_ms`, `cmd_summary` (first 60 chars of the command, trimmed).
 ```
 
 Required: `agent_type`, `description`, `retry_reason`. The subsequent retry produces its own `agent_end` event with `status` = `ok` (retry succeeded) or `deferred` (retry also failed).
+
+#### `gate_open` — a user-approval / clarification gate is shown
+
+```json
+{
+  "ts": "2026-04-15T09:18:30Z",
+  "event": "gate_open",
+  "skill": "deliver",
+  "run_id": "2026-04-15-104502-book-upload",
+  "phase": "3",
+  "gate": "approval",
+  "question": "Approve these spec changes to continue to Phase 4?"
+}
+```
+
+Required: `phase`, `gate`, `question`. `gate` enum: `approval` | `clarify` | `fix-round`. Optional: `context_summary`. Emitted by `scripts/gate.js open` (it derives `skill` + `run_id` from the run-dir path) so the **audit trail** records every gate the run paused at — the live banner comes from the `awaiting_input.json` flag the same script writes; this event is the replayable record the reporter reads. (Claude Code's own permission prompts are surfaced via `awaiting_claude_approval.json` by `notify-hook.js` and are **not** checkpoint events — they're not the pipeline's gates.)
+
+#### `gate_close` — the gate was answered / dismissed
+
+```json
+{
+  "ts": "2026-04-15T09:19:05Z",
+  "event": "gate_close",
+  "skill": "deliver",
+  "run_id": "2026-04-15-104502-book-upload",
+  "duration_ms": 35000
+}
+```
+
+Required: none beyond the common fields. Optional: `duration_ms` (how long the gate was open — `gate.js close` computes it from the open flag's `since`). Pairs with the preceding `gate_open`.
 
 ## Parsing the `<usage>` block
 

--- a/scripts/gate.js
+++ b/scripts/gate.js
@@ -57,12 +57,21 @@ if (!fs.existsSync(runDir)) {
 const filePath = path.join(runDir, 'awaiting_input.json');
 
 if (action === 'close') {
+  let durationMs = null;
   if (fs.existsSync(filePath)) {
+    try {
+      const prev = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (prev && prev.since) {
+        const d = Date.now() - new Date(prev.since).getTime();
+        if (Number.isFinite(d) && d >= 0) durationMs = d;
+      }
+    } catch (_) { /* unreadable flag — close anyway, just no duration */ }
     fs.unlinkSync(filePath);
     console.log(`gate closed: ${filePath}`);
   } else {
     console.log('gate was not open (nothing to close)');
   }
+  emitGateEvent('gate_close', durationMs != null ? { duration_ms: durationMs } : {});
   process.exit(0);
 }
 
@@ -82,3 +91,23 @@ if (context) payload.context_summary = context;
 
 fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
 console.log(`gate opened: ${filePath}`);
+emitGateEvent('gate_open', {
+  phase,
+  gate: payload.gate,
+  question,
+  ...(context ? { context_summary: context } : {}),
+});
+
+// Append a gate checkpoint event so the run's audit trail records every gate the
+// pipeline paused at — not just the transient awaiting_input.json flag the live
+// banner reads. `skill` + `run_id` are derived from the run-dir path
+// (`…/runs/<skill>/<run_id>`). Best-effort: a checkpoints write must NEVER break
+// the gate, so all failures are swallowed.
+function emitGateEvent(event, extra) {
+  try {
+    const runId = path.basename(runDir);
+    const skill = path.basename(path.dirname(runDir));
+    const evt = { ts: new Date().toISOString(), event, skill, run_id: runId, ...extra };
+    fs.appendFileSync(path.join(runDir, 'checkpoints.jsonl'), JSON.stringify(evt) + '\n');
+  } catch (_) { /* never block the gate on a checkpoint write */ }
+}

--- a/scripts/validate-checkpoints.js
+++ b/scripts/validate-checkpoints.js
@@ -16,7 +16,10 @@ const ALLOWED_EVENTS = new Set([
   'phase_start', 'phase_end',
   'agent_start', 'agent_end', 'orch_checkpoint',
   'bash_slow', 'retry',
+  'gate_open', 'gate_close',
 ]);
+
+const ALLOWED_GATE_KINDS = new Set(['approval', 'clarify', 'fix-round']);
 
 const ALLOWED_SKILLS = new Set([
   'discover', 'deliver', 'learn', 'review', 'assess', 'context-refresh',
@@ -131,6 +134,15 @@ function validate(lines) {
         break;
       case 'retry':
         require_(ev, ['agent_type', 'description', 'retry_reason'], lineNo, errors);
+        break;
+      case 'gate_open':
+        require_(ev, ['phase', 'gate', 'question'], lineNo, errors);
+        if (ev.gate && !ALLOWED_GATE_KINDS.has(ev.gate)) {
+          errors.push(`line ${lineNo}: gate_open gate "${ev.gate}" not in ${[...ALLOWED_GATE_KINDS].join('|')}`);
+        }
+        break;
+      case 'gate_close':
+        checkNonNegInt(ev, 'duration_ms', lineNo, errors);
         break;
     }
   });

--- a/scripts/validate-checkpoints.test.js
+++ b/scripts/validate-checkpoints.test.js
@@ -203,6 +203,44 @@ test('retry requires agent_type + description + retry_reason', () => {
   assert(hasErr(r, 'retry missing required field "retry_reason"'));
 });
 
+test('gate_open valid shape passes', () => {
+  const ev = { ts: '2026-04-15T09:18:30Z', event: 'gate_open', skill: 'deliver',
+               run_id: '2026-04-15-104502-book-upload', phase: '3', gate: 'approval',
+               question: 'Approve these spec changes?' };
+  const r = validate(toLines([ev]));
+  assert(r.errors.length === 0, `unexpected errors: ${r.errors.join('; ')}`);
+});
+
+test('gate_open requires phase + gate + question', () => {
+  const ev = { ts: '2026-04-15T09:18:30Z', event: 'gate_open', skill: 'deliver',
+               run_id: '2026-04-15-104502-book-upload' };
+  const r = validate(toLines([ev]));
+  assert(hasErr(r, 'gate_open missing required field "phase"'));
+  assert(hasErr(r, 'gate_open missing required field "gate"'));
+  assert(hasErr(r, 'gate_open missing required field "question"'));
+});
+
+test('gate_open gate-kind enum enforced', () => {
+  const ev = { ts: '2026-04-15T09:18:30Z', event: 'gate_open', skill: 'deliver',
+               run_id: '2026-04-15-104502-book-upload', phase: '3', gate: 'yolo', question: 'x?' };
+  const r = validate(toLines([ev]));
+  assert(hasErr(r, 'not in approval|clarify|fix-round'), r.errors.join(';'));
+});
+
+test('gate_close valid (with duration_ms) passes', () => {
+  const ev = { ts: '2026-04-15T09:19:05Z', event: 'gate_close', skill: 'deliver',
+               run_id: '2026-04-15-104502-book-upload', duration_ms: 35000 };
+  const r = validate(toLines([ev]));
+  assert(r.errors.length === 0, `unexpected errors: ${r.errors.join('; ')}`);
+});
+
+test('gate_close rejects negative duration_ms', () => {
+  const ev = { ts: '2026-04-15T09:19:05Z', event: 'gate_close', skill: 'deliver',
+               run_id: '2026-04-15-104502-book-upload', duration_ms: -1 };
+  const r = validate(toLines([ev]));
+  assert(hasErr(r, 'duration_ms must be non-negative integer'));
+});
+
 test('non-monotonic ts warns', () => {
   const evs = JSON.parse(JSON.stringify(baseRun));
   evs[3].ts = '2026-04-15T09:10:00Z';  // before phase_start

--- a/skills/deliver/phases/dispatch-rules.md
+++ b/skills/deliver/phases/dispatch-rules.md
@@ -133,6 +133,8 @@ See `rules/observability.md` for the exact shape of both events.
 
 **Slow bash commands** (> 5000 ms) → emit `bash_slow` with `duration_ms` and `cmd_summary` (first 60 chars).
 
+**Approval gates** → no manual emission needed. `scripts/gate.js open`/`close` (which you already call to drive the site-view banner — CRITICAL RULE 5) now also appends `gate_open` / `gate_close` events to `checkpoints.jsonl`, so every gate the run paused at is in the audit trail and the reporter can show gate wait-times.
+
 **Orchestrator overhead tracking** — the orchestrator itself consumes tokens (loading skills, reading files, approval gates, scratchpad updates). Capture this with the `orch_checkpoint` event at every phase boundary:
 
 1. **Record the session JSONL byte-offset**:

--- a/templates/checkpoints-event.schema.json
+++ b/templates/checkpoints-event.schema.json
@@ -12,7 +12,7 @@
       "description": "ISO8601 UTC emission time"
     },
     "event": {
-      "enum": ["run_start", "run_end", "phase_start", "phase_end", "agent_start", "agent_end", "orch_checkpoint", "bash_slow", "retry"]
+      "enum": ["run_start", "run_end", "phase_start", "phase_end", "agent_start", "agent_end", "orch_checkpoint", "bash_slow", "retry", "gate_open", "gate_close"]
     },
     "skill": {
       "enum": ["discover", "deliver", "learn", "review", "assess", "context-refresh", "onboard", "feature"],
@@ -129,6 +129,25 @@
           "agent_type": { "type": "string" },
           "description": { "type": "string" },
           "retry_reason": { "type": "string" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "gate_open" } } },
+      "then": {
+        "required": ["phase", "gate", "question"],
+        "properties": {
+          "gate": { "enum": ["approval", "clarify", "fix-round"] },
+          "question": { "type": "string" },
+          "context_summary": { "type": "string" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "gate_close" } } },
+      "then": {
+        "properties": {
+          "duration_ms": { "type": "integer", "minimum": 0 }
         }
       }
     }


### PR DESCRIPTION
## Problem (F8 — audit half)

Approval gates were only a transient `awaiting_input.json` flag (drives the live banner) — they left **no trace in `checkpoints.jsonl`**, so the reporter and any post-hoc replay couldn't see which gates a run paused at or how long the user took.

## Change

Adds `gate_open` + `gate_close` as the 10th/11th canonical events:
- **`rules/observability.md`** documents both (`gate_open` requires `phase`/`gate`/`question`, `gate` ∈ `approval|clarify|fix-round`; `gate_close` optional `duration_ms`).
- **`checkpoints-event.schema.json`** + **`validate-checkpoints.js`** (+5 tests) accept and validate them.
- **`gate.js`** now appends the events itself on open/close — deriving `skill` + `run_id` from the run-dir path (`…/runs/<skill>/<run_id>`) and computing the open duration from the flag's `since` on close. Best-effort: a checkpoints write never breaks the gate. So the orchestrator gets gate logging **for free** from the `open`/`close` calls it already makes (CRITICAL RULE 5); `dispatch-rules.md` notes this.

## Note on the other half of F8
The **poll fallback** for the gate flag files was **already present** in `server.js` (`fs.watchFile` interval-500 on both `awaiting_input.json` and `awaiting_claude_approval.json`) — no change needed.

## Tests
`validate-checkpoints.test.js`: 32 (5 new). A `gate.js open`+`close` smoke emits events that validate clean. Full eval green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)