### PR TITLE
feat(deliver): ux-consultant write-back for cross-cutting design-system deltas

### DIFF
--- a/agents/ux-consultant.md
+++ b/agents/ux-consultant.md
@@ -275,9 +275,23 @@ At the end of your consultation, list what the implementer should put in the fea
 - Component primitives used
 - RTL/i18n edge cases you encountered and the solutions
 - Any new UI vocabulary introduced (new status labels, new interaction patterns)
-- Any design system inconsistencies you noticed during discovery — call them out so someone can address them later
+
+(Design-system changes that are **not** feature-specific — a new shared token, a component to deprecate, a new wrapper convention, or a stale/wrong fact in `DESIGN_SYSTEM.md` — do NOT belong in the feature doc; route them through **Cross-cutting design-system deltas** below.)
 
 This is not a separate memory store — it is content the implementer writes into the feature doc alongside the code. It keeps the repo's design knowledge alive instead of trapped in individual consultation outputs.
+
+---
+
+## Cross-cutting design-system deltas (`## Notes for /learn`)
+
+The feature doc above captures *feature-scoped* knowledge. Some observations are bigger than one feature and belong in the repo's `DESIGN_SYSTEM.md` itself — but you do **not** edit `DESIGN_SYSTEM.md` during a `/deliver` consultation (it's authored at discovery and refreshed under human approval, never rewritten mid-feature). Instead, when you notice a **cross-cutting** design-system delta, emit a `## Notes for /learn` section at the very end of your output — one bullet each for:
+
+- a new shared **design token / primitive** that should be added to the design system,
+- a component that should be **marked deprecated / "avoid"** (with the reason),
+- a new **wrapper / composition convention** the repo has adopted,
+- a **stale or wrong fact in `DESIGN_SYSTEM.md`** you found while orienting.
+
+The orchestrator routes that section to the run's `run-notes.md`; the end-of-run `/learn` offering then curates it into `DESIGN_SYSTEM.md` with user approval (it is one of `/learn`'s repo-durable targets). This is the same capture channel the product-owner and solution-architect use — *consultant proposes, `/learn` applies* — so the human-owned design doc is never silently rewritten. Omit the section entirely when there's nothing cross-cutting to report.
 
 ---
 

--- a/skills/deliver/phases/dispatch-rules.md
+++ b/skills/deliver/phases/dispatch-rules.md
@@ -111,7 +111,7 @@ Starting at Phase 4.5, implementation sub-tasks and reviewer findings are persis
 
 ### Learning notes capture (`run-notes.md`)
 
-Some dispatched agents (primarily the product-owner and solution-architect) surface **durable observations** that aren't part of the feature they're producing — a gap in `platform.md`, a domain rule the user corrected, a recurring clarification, a convention worth recording. Those used to scroll past in chat and get lost. Now each such agent ends its output with an optional `## Notes for /learn` section.
+Some dispatched agents (the product-owner, solution-architect, and ux-consultant) surface **durable observations** that aren't part of the feature they're producing — a gap in `platform.md`, a domain rule the user corrected, a recurring clarification, a cross-cutting design-system delta, a convention worth recording. Those used to scroll past in chat and get lost. Now each such agent ends its output with an optional `## Notes for /learn` section.
 
 **After any dispatch whose returned output contains a `## Notes for /learn` section, append that section's bullets to `{run_dir}/run-notes.md`** (create it on first write; one bullet per observation, prefixed with the source agent + phase, e.g. `- [product-owner / Phase 1] …`). Do not act on them mid-run — they are candidate learnings, applied (or discarded) at the end-of-run `/learn` offering in Phase 8.6, which reads this file. This is the write half of continuous learning; the read half is each agent mining `platform.md` § Established Patterns at the start of its run.
 


### PR DESCRIPTION
## Problem (B4)

The ux-consultant authors `DESIGN_SYSTEM.md` at discovery and reads it during deliver, but **never writes back**. Cross-cutting design facts it noticed mid-feature — a new shared token, a component to deprecate, a new wrapper convention, a stale fact in `DESIGN_SYSTEM.md` — got only a vague *"call them out so someone can address them later"* and were lost.

## Change

Reuses the run-notes channel built in WS7. The ux-consultant now emits a `## Notes for /learn` section for **cross-cutting** deltas only (feature-scoped knowledge still goes in the feature doc, unchanged). The orchestrator routes it to `run-notes.md`, and the end-of-run `/learn` offering curates it into `DESIGN_SYSTEM.md` with user approval — `DESIGN_SYSTEM.md` is already one of `/learn`'s repo-durable targets.

*Consultant proposes, `/learn` applies* — the human-owned design doc is never silently rewritten mid-feature (the consultant has no write path to it in design mode). `dispatch-rules.md`'s capture rule now lists the ux-consultant alongside the PO + SA.

## Tests
Doc-only; full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)