### PR TITLE
feat(deliver): assessor recurring cross-repo gap checklist (write + read)

### DIFF
--- a/skills/deliver/phases/dispatch-rules.md
+++ b/skills/deliver/phases/dispatch-rules.md
@@ -111,7 +111,7 @@ Starting at Phase 4.5, implementation sub-tasks and reviewer findings are persis
 
 ### Learning notes capture (`run-notes.md`)
 
-Some dispatched agents (the product-owner, solution-architect, and ux-consultant) surface **durable observations** that aren't part of the feature they're producing — a gap in `platform.md`, a domain rule the user corrected, a recurring clarification, a cross-cutting design-system delta, a convention worth recording. Those used to scroll past in chat and get lost. Now each such agent ends its output with an optional `## Notes for /learn` section.
+Some dispatched agents (the product-owner, solution-architect, ux-consultant, and assessor) surface **durable observations** that aren't part of the feature they're producing — a gap in `platform.md`, a domain rule the user corrected, a recurring clarification, a cross-cutting design-system delta, a recurring cross-repo integration gap class, a convention worth recording. Those used to scroll past in chat and get lost. Now each such agent ends its output with an optional `## Notes for /learn` section.
 
 **After any dispatch whose returned output contains a `## Notes for /learn` section, append that section's bullets to `{run_dir}/run-notes.md`** (create it on first write; one bullet per observation, prefixed with the source agent + phase, e.g. `- [product-owner / Phase 1] …`). Do not act on them mid-run — they are candidate learnings, applied (or discarded) at the end-of-run `/learn` offering in Phase 8.6, which reads this file. This is the write half of continuous learning; the read half is each agent mining `platform.md` § Established Patterns at the start of its run.
 

--- a/skills/deliver/phases/phase-6-assess.md
+++ b/skills/deliver/phases/phase-6-assess.md
@@ -37,6 +37,7 @@ To keep token cost proportional to that value, **pass only these inputs** (do NO
 4. **Updated spec file paths** — one per affected service (the assessor reads them directly to verify wire shapes)
 5. **Files-modified list per repo** — extract from the scratchpad's Implementation Tasks "Files Changed" column. This lets the assessor target its reads to what actually changed, not the whole repo.
 6. **Endpoint inventory** — a flat list of `method path → DTO` entries extracted from the spec diffs. Pre-compute this in the orchestrator from Phase 3 output; the assessor uses it as its wire-shape checklist.
+7. **Recurring cross-repo gap checklist** — IF `{workspace_root}/{slug}/context/cross-repo-checklist.md` exists, pass its **contents**. It is a small, bounded, curated list of gap *classes* this workspace has hit before (written by `/learn` from prior assessor findings); the assessor folds it into its plan at Step 1.5 to check those classes proactively. This is a deliberately separate sidecar — passing it does **not** breach the "no `platform.md`" rule below, because the whole point of the sidecar is to stay small and assessor-only. Skip this input if the file doesn't exist yet.
 
 Do NOT pass requirements or architecture files in the prompt. The assessor is forbidden from re-reading them — if it needs a specific FR/EC detail, it reads the `phase-5-5-code-review.md` which already maps findings to requirements. This is a deliberate scope narrowing.
 
@@ -67,6 +68,10 @@ FILES CHANGED (target your reads to these):
 
 ENDPOINT INVENTORY (pre-computed from spec diffs — use as your wire-shape checklist):
 {flat list: method path → response DTO | request DTO}
+
+{if {workspace_root}/{slug}/context/cross-repo-checklist.md exists, include:}
+RECURRING CROSS-REPO GAP CHECKLIST (gap classes this workspace has shipped before — check each proactively per Step 1.5):
+{paste the contents of context/cross-repo-checklist.md}
 
 SCOPE: cross-repo integration only.
 1. Wire shapes agree across backend ↔ frontend ↔ mock for every endpoint in the inventory.

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -15,6 +15,7 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 
 **Output scopes** (tier classification for every finding):
 - **Workspace durable** → updates `{workspace_root}/{slug}/context/platform.md` (typically the `Established Patterns` section)
+  - **Exception — recurring cross-repo integration gap *classes*** (surfaced by the assessor via its `## Notes for /learn`, e.g. "role-gated backend endpoints repeatedly ship without the matching frontend route guard") go to the dedicated sidecar `{workspace_root}/{slug}/context/cross-repo-checklist.md`, **not** `platform.md`. Only the Phase 6 assessor loads that sidecar, so keeping these out of `platform.md` keeps the always-loaded doc lean. **Dedupe** against existing entries (merge a near-duplicate, don't add a second) and **cap** the file at ~150 lines — if it would exceed that, drop the least-recurring entry. It is a tight checklist of gap *classes*, not an append-only log; create it on the first such finding.
 - **Repo durable** → updates `{repo}/CLAUDE.md` or `{repo}/agent-context/*` or `DESIGN_SYSTEM.md` (frontend — path resolved via `config.repos[repo].design_system_path`, falling back to standard candidates)
 - **Plugin-level** → flagged in the log only (not auto-applied; requires maintainer review)
 - **Run-local** → no propagation; already captured in the run's outputs, mentioned but not acted on

--- a/templates/agents/assessor.md.template
+++ b/templates/agents/assessor.md.template
@@ -25,7 +25,7 @@ You are a **cross-repo** quality assessor for the **{{WORKSPACE_NAME}}** platfor
 
 Your exact inputs vary by dispatch — read what you are given, do not assume the full set:
 - **Always**: implementation task statuses (COMPLETED / BLOCKED / SKIPPED / FAILED), the updated OpenAPI spec(s), the Phase 5.5 code-review report, and a files-modified list per repo.
-- **`/deliver` Phase 6 (narrowed)**: you also get a pre-computed endpoint inventory to use as your wire-shape checklist. You do **not** receive — and must not re-read — the requirements doc, the technical design, or `platform.md`; if you need a specific FR/EC detail, take it from the code-review report, which maps findings to requirements. This is a deliberate scope narrowing.
+- **`/deliver` Phase 6 (narrowed)**: you also get a pre-computed endpoint inventory to use as your wire-shape checklist, and — when it exists — this workspace's **recurring cross-repo gap checklist** (`context/cross-repo-checklist.md`): a small, curated list of gap *classes* this workspace has shipped before, used at Step 1.5. You do **not** receive — and must not re-read — the requirements doc, the technical design, or `platform.md`; if you need a specific FR/EC detail, take it from the code-review report, which maps findings to requirements. (The gap checklist is a deliberately separate small sidecar, NOT part of `platform.md`, so it stays cheap and only you load it.) This is a deliberate scope narrowing.
 - **`/assess` (standalone)**: you also get the requirements doc and technical design when they exist, plus a platform-context path.
 
 You then read the actual implementation files across repos and assess **cross-repo integration**, not per-file craft.
@@ -43,6 +43,9 @@ For each task:
 
 ### Step 1: Build the cross-repo checklist from your provided inputs
 Build a checklist of what to verify across repos from the inputs you were given — the endpoint inventory plus the FR/EC mapping inside the code-review report on a `/deliver` Phase 6 dispatch; the requirements + technical design when a standalone `/assess` provided them. Do not request re-reads of files outside your dispatch's named input set.
+
+### Step 1.5: Fold in the recurring-gap checklist (if provided)
+If the dispatch handed you this workspace's recurring cross-repo gap checklist, add each entry to your verification plan as a class to check **proactively** — these are gaps this workspace has shipped before (e.g. "a role-gated backend endpoint without the matching frontend route guard", "mock and backend disagree on an enum's casing", "an event emitted with no registered consumer"). Walking them up front is cheaper than re-discovering the same class every run. The checklist is advisory and bounded, not exhaustive — still run the full passes below.
 
 ### Step 2: Wire-shape agreement (backend ↔ frontend ↔ mock)
 For every new or modified endpoint, open the backend DTO and frontend TypeScript type side by side. Field names, required fields, optionality, enum values must all match. Verify mock handler response shapes match real backend.
@@ -68,5 +71,8 @@ If the app needs an authenticated session for the gated role, use the workspace'
 
 ### Step 6: Produce report
 Score: `PASS` / `PARTIAL` / `FAIL` with specific cross-repo gaps noted and fix assignments per repo. A Step 5.5 `ISSUES-FOUND` with a happy-path 4xx/5xx or white-screen means the score cannot be `PASS`.
+
+### Step 7: Surface recurring gap classes (`## Notes for /learn`)
+You keep no private memory — but when a gap you found looks like a **recurring class** (the kind this workspace is likely to reproduce on the next feature, not a one-off specific to this one), surface it so the crew gets better at catching it. End your output with a `## Notes for /learn` section, one bullet per class, stated **generally** (e.g. "role-gated backend endpoints repeatedly ship without the matching frontend route guard" — not the single instance). The orchestrator routes that section to the run's `run-notes.md`; the end-of-run `/learn` offering curates approved entries into `context/cross-repo-checklist.md` — a small, bounded sidecar that only future assessor dispatches load. It is deliberately **not** `platform.md` (which every agent reads every dispatch), so capturing gaps here never taxes the rest of the crew. This sidecar is the same list Step 1.5 reads back — your write becomes the next run's proactive checklist. Omit the section entirely when nothing recurring turned up; a one-off gap belongs only in the report's fix assignments.
 
 {{QUALITY_STANDARDS}}


### PR DESCRIPTION
## Problem (C5)

The assessor has **no memory** — every Phase 6 run re-derives cross-repo expectations from scratch and re-finds the same gap *classes* (role-gate without a frontend route guard, mock/backend enum-casing drift, event with no consumer). But the obvious fix — accumulate them in `platform.md` § Established Patterns — is wrong: `platform.md` is the **always-loaded hot path** every agent reads each dispatch, so growing it there taxes the whole crew.

## Design (per discussion — capture-auto, apply-gated, hot-path-safe)

A dedicated **bounded sidecar** `context/cross-repo-checklist.md` that **only the Phase 6 assessor** loads (same split-out-of-platform.md principle as `observability.json`):

- **WRITE** — the assessor ends its output with a `## Notes for /learn` section for recurring gap *classes* (not one-offs). Captured to `run-notes.md` by the existing dispatch-rules rule (the assessor is now listed there).
- **APPLY** — `/learn` routes those findings to the sidecar (a new workspace-durable target, explicitly **not** `platform.md`), **deduped** and **capped at ~150 lines**. Capture is automatic; applying stays human-gated (end-of-run offer + per-finding approval).
- **READ** — `phase-6-assess.md` passes the sidecar's contents into the dispatch when it exists; the assessor folds each class into its plan at **Step 1.5** and checks it proactively. Passing this *small* sidecar doesn't breach the "no `platform.md`" rule — that's exactly why it's a separate file.

Net: the assessor's own surfaced gaps become the next run's proactive checklist; the hot path stays lean; nothing reaches the sidecar without approval.

## Tests
Doc/template-only; full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)