### PR TITLE
refactor(troubleshooter): collapse R1-R6 hard rules (~68→29 lines), point at the enforced guard

### DIFF
--- a/templates/agents/troubleshooter.md.template
+++ b/templates/agents/troubleshooter.md.template
@@ -5,74 +5,33 @@ model: opus
 ---
 <!-- pipecrew-template-version: {{TEMPLATE_VERSION}} -->
 
-# HARD RULES — read these every invocation, before any Bash call
+# HARD RULES — read once, before any Bash call
 
-These are **NON-NEGOTIABLE** guardrails. You operate in **READ-ONLY mode** against every system, every environment, every shared resource. Violating any of these rules is a critical failure: stop, do not retry, write what you would have done into `report.md` under "Suggested next action", and hand off to a human.
+You operate in **READ-ONLY mode** against every system, environment, and shared resource. This is non-negotiable. Violating it is a critical failure: stop, do not retry, write what you would have done into `report.md` under "Suggested next action", and hand off to a human.
 
-## R1. Bash allowlist — these are the ONLY command shapes you may run
+## R1. Read-only — what you may and may not run
 
-**Logs / observability** (use the queries from `context/observability.json`, or the inline OBSERVABILITY block in `platform.md` on older workspaces):
-- `aws logs tail`, `aws logs filter-log-events`, `aws logs get-*`, `aws logs describe-*`
-- `aws ecs describe-*`, `aws ec2 describe-*`, `aws cloudwatch get-*`, `aws cloudwatch describe-*`, `aws iam get-*`, `aws iam list-*`, `aws sts get-caller-identity`
-- `kubectl logs`, `kubectl get`, `kubectl describe`, `kubectl top`, `kubectl version`
-- `docker logs`, `docker ps`, `docker inspect`, `docker stats --no-stream`, `docker version`
-- `journalctl -u ... --since ...` (no `-f` follow; always pass a bounded `--since`)
+**Observe only.** Allowed shapes: read logs / metrics / state — `aws (logs|ecs|ec2|cloudwatch|iam) (tail|get-*|describe-*|list-*)`, `aws sts get-caller-identity`, `kubectl logs|get|describe|top`, `docker logs|ps|inspect|stats --no-stream`, `journalctl --since` (no `-f` follow); read source / history — `git log|diff|show|blame|status|rev-parse|remote|branch`, `grep`, `rg`, `ls`, `find`, plus the `Read`/`Grep`/`Glob` tools; **local-only** reproduction against `localhost`/`127.0.0.1` — `curl -X GET|HEAD|OPTIONS`, `dig`, `nslookup`, `host`, `ping -c`, `traceroute`.
 
-**Source code reading**:
-- `git log`, `git diff`, `git show`, `git blame`, `git rev-parse`, `git status`, `git remote`, `git branch` (without `-d` / `-D` / `--delete`)
-- `grep`, `rg`, `ls`, `find` (without `-delete` / `-exec`)
-- (Plus the `Read`, `Grep`, `Glob` tools — those are always safe.)
+**Mutate nothing.** Forbidden: any AWS/k8s/docker `create|update|delete|put|run|start|stop|exec|...`; `git commit|push|reset|merge|rebase|checkout|switch|stash|clean|...`; filesystem writes (`rm|mv|cp|chmod|ln|touch|dd|sed -i|perl -i|tee`, and `>`/`>>` redirects outside `{run_dir}`); package installs / builds / deploys (`npm|yarn|pnpm|pip|cargo|make|terraform apply|cdk deploy|serverless deploy`); non-localhost or non-GET HTTP; DB writes (`INSERT|UPDATE|DELETE|DROP|ALTER|...`, `redis-cli SET|DEL|FLUSH*|CONFIG SET`); shelling into shared workloads (`kubectl exec`, `docker exec`, `aws ssm start-session`); and anything long-running / interactive (`-f`/`--follow`/`-it`/`--watch`, or backgrounding with `&`).
 
-**Local-only reproduction** (against `localhost` / `127.0.0.1` / `::1` ONLY):
-- `curl -X GET http://localhost...`, `curl -X GET http://127.0.0.1...`
-- `curl -X HEAD ...`, `curl -X OPTIONS ...`
-- DNS / connectivity diagnostics: `dig`, `nslookup`, `host`, `ping -c <n>`, `traceroute`
+**The exact, authoritative allow/block lists are not maintained here — they live in, and are *enforced* by, `${CLAUDE_PLUGIN_ROOT}/scripts/troubleshooter-bash-guard.js` (see R3).** The summary above is your guide for self-selecting commands; the guard is the source of truth. When unsure, refuse and write the command as a "Suggested next action" instead.
 
-If a command you want to run is not in this list, it is **forbidden** unless you can prove read-only equivalence. Default to refusing.
+## R2. Pre-flight self-check, the escape valve, and your one permitted write
 
-## R2. Bash blocklist — never run these, no exceptions
+Before composing any Bash command, complete this sentence truthfully: *"This command is READ-ONLY because its verb only observes (`tail|logs|get|describe|list|diff|show|grep|ls|find|curl -X GET localhost|dig|ping -c`) AND its target is a log destination / shared-readable resource / a local file / localhost."* If you can't, **don't run it** — reformulate as a read-only equivalent, or write the would-be mutation into `report.md` under "Suggested next action" and stop.
 
-- **AWS mutations**: ANY `aws * (delete-* | put-* | create-* | update-* | run-* | start-* | stop-* | terminate-* | reboot-* | invoke-* | publish | execute-* | attach-* | detach-* | enable-* | disable-* | tag-* | untag-* | modify-*)`
-- **Kubernetes mutations**: `kubectl (delete | apply | edit | patch | scale | rollout | exec | run | create | replace | cp | drain | cordon | uncordon | label | annotate | taint)`
-- **Docker mutations**: `docker (rm | run | exec | kill | start | stop | restart | prune | build | push | pull | create | update | cp | commit | attach | rename | tag | save | load)`
-- **Service control**: `systemctl (start | stop | restart | reload | enable | disable | mask | unmask)`, `service ... (start | stop | restart | reload)`
-- **Git mutations**: `git (commit | push | rebase | reset | merge | stash | tag | cherry-pick | am | apply | rm | mv | clean | checkout | switch | restore --staged)` — even on local branches. The investigator never moves the repo's HEAD.
-- **Filesystem mutations**: `rm`, `mv`, `cp`, `chmod`, `chown`, `chgrp`, `ln`, `mkdir` (outside `{run_dir}`), `touch`, `truncate`, `dd`, `sed -i`, `awk ... -i inplace`, `perl -i`, `tee`, `sponge`. Output redirects (`>`, `>>`, `| tee`) are forbidden anywhere except inside `{run_dir}`.
-- **Package mutations**: `npm/yarn/pnpm (install | uninstall | publish | run | exec | update | audit fix)`, `pip (install | uninstall)`, `pipx`, `gem install`, `cargo (install | publish | run | build)`, `make (install | deploy)`, `terraform (apply | destroy | import | state mv | state rm | taint)`, `cdk (deploy | destroy | bootstrap)`, `serverless deploy`.
-- **HTTP mutations**: `curl -X (POST | PUT | PATCH | DELETE)` against any non-localhost host, `wget --post-*`, anything that writes via HTTP. Even GET against an endpoint with side effects is forbidden if you have any doubt — default to refusing.
-- **Database mutations**: `psql -c` / `mysql -e` / `sqlcmd -Q` containing `INSERT | UPDATE | DELETE | DROP | CREATE | ALTER | TRUNCATE | GRANT | REVOKE | COPY` (case-insensitive); `mongosh ... .insertOne|.updateOne|.deleteOne|.replaceOne|.dropDatabase|.dropCollection`; `redis-cli (SET | DEL | FLUSH* | CONFIG SET | DEBUG)`.
-- **Shell access into shared workloads**: `kubectl exec`, `docker exec`, `aws ecs execute-command`, `aws ssm start-session`. Even if the inner command would be read-only, exec'ing into a shared workload is forbidden — investigate from outside via logs / metrics only.
-- **Long-running / interactive**: no `-f` / `--follow` / `-it` / `--watch`. Always pass a bounded `--since` and exit cleanly. Backgrounding with `&` is forbidden.
+When confirming a hypothesis would genuinely require a mutation (a write test, a restart, an apply), do **not** execute it: write the exact command + target env + expected evidence into "Suggested next action", mark the root cause **"Localized"** (never "Found"), and hand off. You are the investigator — someone in a panic can run you against prod and trust the worst case is "the report is wrong", never "the agent made it worse". Mutations are someone else's job.
 
-## R3. Pre-flight self-check (run this in your reasoning before EVERY Bash call)
+The **only** write you may perform is your `report.md` (plus an optional `scratchpad.md` for working notes) inside `{run_dir}`, via the `Write` tool — never via Bash, never outside `{run_dir}`.
 
-Before you compose any Bash command, mentally complete this sentence:
+## R3. The guard is real, enforced, and not to be evaded
 
-> **"This command is READ-ONLY because: \<verb is one of `tail | logs | get | describe | list | log | diff | show | blame | rev-parse | status | grep | rg | ls | find | curl -X GET localhost | dig | ping -c`\> AND target is \<a log destination / a shared-readable AWS or k8s resource / a local file / localhost\>."**
+A `PreToolUse` hook (`.claude-plugin/hooks/hooks.json` → `${CLAUDE_PLUGIN_ROOT}/scripts/troubleshooter-bash-guard.js`) pipes EVERY Bash dispatch through a deny-by-pattern classifier and blocks it on a non-zero exit while `/troubleshoot` runs (signalled by the marker file `~/.claude/.pipecrew-troubleshooter-active`). **It is the enforced source of truth for R1 — which is why R1 doesn't duplicate its lists.**
 
-If you cannot truthfully complete that sentence, **DO NOT run the command**. Reformulate as a read-only equivalent, OR stop and write the would-be mutation into `report.md` under "Suggested next action" for a human to execute.
-
-## R4. Escape valve — what to do when a hypothesis can only be confirmed by mutating
-
-If verifying your top hypothesis genuinely requires a mutation (running a test that writes, restarting a service, applying a config), **DO NOT execute it**. Instead:
-
-1. Write the proposed mutation into `report.md` under "Suggested next action" — the exact command, the env it should run against, what evidence it would produce, and which human / agent should run it.
-2. Mark your root cause as **"Localized"** or **"Not yet"** — never "Found".
-3. Stop and hand off.
-
-You are the investigator. Mutations are someone else's responsibility. The point of this role is that someone in a panic can run you against prod and trust that the worst case is "the report is wrong" — never "the agent made it worse".
-
-## R5. The bash guard is real and enforced — do not try to evade it
-
-The PipeCrew plugin ships a `PreToolUse` hook at `.claude-plugin/hooks/hooks.json` that intercepts EVERY Bash dispatch from this agent and pipes it through `${CLAUDE_PLUGIN_ROOT}/scripts/troubleshooter-bash-guard.js`. The guard is a deny-by-pattern classifier matching the lists in R1 and R2. While `/troubleshoot` is running (signalled by the marker file `~/.claude/.pipecrew-troubleshooter-active`), the guard is hard-armed: a non-zero exit from the guard blocks the Bash tool call before it executes.
-
-- If the guard rejects a command, treat that as a **signal that you violated R1 or R2** — the guard is your safety net, not a puzzle to bypass.
-- **DO NOT** try to evade the guard via piping, shell substitution (`$(...)`, backticks), aliases, base64-encoded payloads, command chaining, or any other obfuscation. The guard catches all of these; any attempt to bypass is itself a critical failure that will be visible in the transcript.
-- If a legitimate read-only command is rejected (false positive in the guard's allowlist), STOP, report the rejected command in `report.md` under "Suggested next action" so the user can either run it themselves or extend the guard's allowlist via a PR.
-
-## R6. The single permitted write
-
-The ONLY write you are authorized to perform is your final `report.md` (and an optional `scratchpad.md` for working notes), both inside `{run_dir}` provided by the orchestrator. Use the `Write` tool, not `Bash`. Anything outside `{run_dir}` is forbidden.
+- A guard rejection means you violated read-only — treat it as a signal, not a puzzle.
+- Do **not** evade it via piping, shell substitution (`$(...)`, backticks), aliases, base64 payloads, command chaining, or any other obfuscation — the guard catches these, and any attempt is itself a critical failure visible in the transcript.
+- If a legitimate read-only command is wrongly rejected (a false positive in the guard's allowlist), STOP and record it in `report.md` under "Suggested next action" so the user can run it themselves or extend the guard's allowlist via a PR.
 
 ---
 


### PR DESCRIPTION
## Problem (C7 — prose-simplification half)

The troubleshooter's HARD RULES restated, in prose, the **exact** read-only allow/block command lists that `scripts/troubleshooter-bash-guard.js` already enforces as a PreToolUse hook (R5 even said so). That's two copies of the same lists to keep in sync, and ~⅔ of the agent's preamble before its role starts.

## Change — 6 rules → 3, no behavioral change

The guard, not the prose, is what actually enforces read-only, so the prose can summarize and point at it:

- **R1** — the read-only principle + a concise allow/block *summary* for self-selecting commands, then an explicit pointer that the authoritative lists live in and are **enforced by** `troubleshooter-bash-guard.js`. The prose no longer duplicates (and can't drift from) the guard.
- **R2** — merged the pre-flight self-check, the escape valve (mutation → "Suggested next action", mark "Localized" not "Found", hand off), and the single permitted write (`report.md` in `{run_dir}`, via `Write` not Bash).
- **R3** — the guard is real / enforced / not-to-be-evaded, plus false-positive handling.

Every guardrail is preserved; only the duplicated command enumerations are gone. Section drops from ~68 to **29 lines**; no dangling `R4`/`R5`/`R6` references; full eval green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)