### PR TITLE
feat(deliver): hint that /learn can capture post-run hand-fixes (--branch)

### DIFF
--- a/skills/deliver/phases/phase-8-pr-publish.md
+++ b/skills/deliver/phases/phase-8-pr-publish.md
@@ -209,12 +209,17 @@ Pull Requests:
    repo CLAUDE.md / agent-context). You approve each finding before
    anything is applied. Run it once per PR after meaningful review activity.
 
-Want INSTANT feedback on this run right now? Captures corrections you
-made during dispatch, decisions you pushed back on, gates you reshaped —
-useful for the architect / implementers learning your conventions.
+Want feedback captured into your workspace docs?
 
-  yes   → run /learn --run={run_id} now
-  later → skip (you can run /learn --run={run_id} or /learn --pr=<url> any time)
+  yes   → run /learn --run={run_id} now — captures THIS pipeline run
+          (corrections you made at gates, decisions you pushed back on,
+          the notes the agents flagged this run)
+  later → if you'll keep tweaking the code in this session, that's often the
+          BETTER moment to learn: finish your fixes, then run
+          /learn --branch=feature/{feature-slug}  (add --note="why" for intent
+          a diff can't show). It diffs the whole branch against base, so it
+          learns from your follow-up hand-edits too — not just what the
+          pipeline produced. Or /learn --pr=<url> once the PR has review activity.
   no    → permanently skip for this run
 
 Choice?
@@ -228,11 +233,15 @@ Choice?
 📌 You can publish PRs later with:
      /deliver --resume --workspace={slug} --with-pr
 
-Want INSTANT feedback on this run right now? Captures corrections you
-made during dispatch, decisions you pushed back on, gates you reshaped.
+Want feedback captured into your workspace docs?
 
-  yes   → run /learn --run={run_id} now
-  later → skip (you can run /learn --run={run_id} any time)
+  yes   → run /learn --run={run_id} now — captures THIS pipeline run
+          (corrections at gates, decisions you pushed back on, agent notes)
+  later → if you'll keep tweaking the code in this session, that's often the
+          BETTER moment to learn: finish your fixes, then run
+          /learn --branch=feature/{feature-slug}  (add --note="why" for intent
+          a diff can't show). It diffs the whole branch against base, so it
+          learns from your follow-up hand-edits too — not just the pipeline output.
   no    → permanently skip for this run
 
 Choice?


### PR DESCRIPTION
## What

After `/deliver` finishes, users often keep tweaking the code in the same session and *then* want `/learn` to learn from those follow-up fixes. The end-of-run feedback offering only pointed at `/learn --run` (which sees the pipeline's own outputs + the agents' run-notes, **not** edits you make afterwards) and `--pr` (post-push) — so the "I'll fix a few things, then learn" workflow wasn't surfaced.

## Change

Reframed the Phase 8.6 offering's `now`-vs-`later` choice to name the right moment **and** the right source:

- **yes** → `/learn --run={run_id}` now — captures THIS pipeline run (gate corrections, pushed-back decisions, the agents' surfaced notes).
- **later** → if you'll keep fixing the code this session, that's often the *better* moment: finish, then run `/learn --branch=feature/{feature-slug}` — it diffs the whole branch against base, so your **follow-up hand-edits are included**, not just what the pipeline produced (add `--note="why"` for intent a diff can't show; or `--pr=<url>` once the PR has review activity).

## Note
No behavior change — `/learn --branch` already diffs `base...branch` (mode 2c). This just tells the user that's how to learn from their post-`/deliver` fixes. (`--run` and `--branch` capture different things — pipeline-run vs branch-diff; the offering now makes that explicit.)

Doc-only; full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)