### PR TITLE
fix(memory): stop publishing non-durable files + redacting paths as secrets

### DIFF
--- a/scripts/redact-secrets.js
+++ b/scripts/redact-secrets.js
@@ -114,8 +114,13 @@ const RULES = [
     kind: 'token',
     // Charset deliberately EXCLUDES path separators (. / -) so dotted/slashed/
     // hyphenated code identifiers and paths split into short harmless segments.
-    // Underscore and base64 chars (+/=) are kept (real secrets use them).
-    re: /(?<![A-Za-z0-9_+/=~])([A-Za-z0-9_+/=~]{20,})(?![A-Za-z0-9_+/=~])/g,
+    // NOTE: '/' MUST stay out of this class — including it makes long slash-paths
+    // (e.g. /v1/publishers/publishers/user/) and slash-joined enum lists
+    // (PASSED_LEVEL_1/2/3) match, and isCredentialish()'s base64ish test then
+    // flags the lone '/' as a secret. Keep underscore + base64 padding chars
+    // (+ = ~) only; real base64 secrets also carry mixed case / length and are
+    // caught by isCredentialish without needing '/'.
+    re: /(?<![A-Za-z0-9_+=~])([A-Za-z0-9_+=~]{20,})(?![A-Za-z0-9_+=~])/g,
     replace: (full, tok) => (isCredentialish(tok) ? '[REDACTED-token]' : full),
   },
 ];

--- a/scripts/sync-memory.js
+++ b/scripts/sync-memory.js
@@ -126,7 +126,15 @@ if (DRY) {
   console.log(`sync-memory: --dry-run (mode=${syncMode}), would commit:\n` + (st.stdout || '(no changes)'));
   process.exit(0);
 }
-git(['add', '-A']);
+// Stage an explicit ALLOW-LIST of durable-doc paths only — never `git add -A`.
+// A deny-list (.gitignore) can't anticipate arbitrary junk a user may drop in the
+// workspace dir (e.g. a "copy of claude code session/" transcript dump), and such
+// content would otherwise be committed UN-redacted (redaction only runs over
+// context/agents/history). Allow-listing guarantees only known docs are published.
+const ALLOW = ['context', 'agents', 'history', 'config.portable.json', '.gitignore'];
+const toStage = ALLOW.filter((rel) => fs.existsSync(path.join(wsDir, rel)));
+// `-A` scoped to each pathspec so deletions within the durable dirs are captured too.
+if (toStage.length) git(['add', '-A', '--', ...toStage]);
 const staged = git(['diff', '--cached', '--name-only']).stdout.trim();
 if (!staged) { console.log('sync-memory: nothing changed — no commit'); process.exit(0); }
 

--- a/templates/workspace-memory.gitignore
+++ b/templates/workspace-memory.gitignore
@@ -1,29 +1,31 @@
 # pipecrew workspace memory repo — .gitignore
-# Versions the DURABLE workspace memory (context/, agents/, history/,
-# config.portable.json). Everything below is local-only / machine-specific /
-# run noise and must NOT be pushed. See docs/design/github-memory.md.
+# ALLOW-LIST by design: ignore everything, then un-ignore ONLY the durable
+# workspace memory (context/, agents/, history/, config.portable.json).
+# This is defense-in-depth alongside sync-memory.js's allow-listed `git add`:
+# anything a user drops into the workspace dir (e.g. a "copy of claude code
+# session/" transcript dump, scratch files, exports) is ignored by default and
+# can never be committed/pushed — even by a stray `git add -A`.
+# See docs/design/github-memory.md.
 
-# --- machine-specific config (absolute repo paths) ---
-config.json
-config.local.json
+# 1. Ignore everything at the root.
+/*
 
-# --- run artifacts (scratchpads, checkpoints, outputs, reports) ---
-# Large + churny; token trends come from the reporter locally, not git.
-runs/
+# 2. Un-ignore the .gitignore itself and the durable-doc paths.
+!/.gitignore
+!/context/
+!/agents/
+!/history/
+!/config.portable.json
 
-# --- transient / in-flight markers ---
-.observability-draft.json
-.in_use/
-awaiting_input.json
-*.autoapprove
-.autoapprove-*
+# 3. Within the un-ignored durable dirs, still exclude transient/in-flight noise.
+context/**/.observability-draft.json
+**/.in_use/
+**/awaiting_input.json
+**/*.autoapprove
+**/.autoapprove-*
 
-# --- local Claude Code settings (may contain machine paths / allow-rules) ---
-.claude/settings.local.json
-.claude/worktrees/
-
-# --- OS / editor cruft ---
-.DS_Store
-Thumbs.db
-*.swp
-*~
+# 4. OS / editor cruft (in case it lands inside a durable dir).
+**/.DS_Store
+**/Thumbs.db
+**/*.swp
+**/*~


### PR DESCRIPTION
## Summary

Two workspace-memory bugs surfaced during a real `/discover` incremental run on a live workspace. Both could leak or corrupt data in a shared memory repo.

### 1. `sync-memory.js` published non-durable files (data leak)
`sync-memory.js` staged with `git add -A` over a **deny-list** `.gitignore`. Anything a user drops into the workspace dir that isn't explicitly ignored gets committed and pushed. In the wild, a `copy of claude code session/` transcript dump (25 session + subagent `.jsonl` files) was published to a private memory repo — and **un-redacted**, since redaction only runs over `context/`, `agents/`, `history/`.

**Fix (defense-in-depth):**
- Stage an explicit **allow-list** (`context`, `agents`, `history`, `config.portable.json`, `.gitignore`) instead of `git add -A`.
- Flip `templates/workspace-memory.gitignore` to **allow-list style** (`/*` then un-ignore the durable docs), so even a stray `git add -A` can't sweep in junk.

### 2. `redact-secrets.js` corrupted real docs (false positives)
Rule 6's character class included `/`, contradicting its own comment ("EXCLUDES path separators `. / -`"). Long slash-paths (`/v1/publishers/publishers/user/`) and slash-joined enums (`PASSED_LEVEL_1/2/3`) matched the 20+ char token rule, and `isCredentialish()`'s `base64ish` test flagged the lone `/` as a secret — replacing legitimate content in `platform.md` / `audit-findings.md` with `[REDACTED-token]`.

**Fix:** remove `/` from rule 6's character class to match the documented intent. Validated: genuine secrets (mixed-case / 32-char tokens) are still caught; paths and enum lists are spared.

## Test notes
- Re-ran the fixed redactor over a corrupted workspace `context/`: **0 false positives**, genuine credential redactions preserved.
- Verified allow-listed staging publishes only the durable docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)