### PR TITLE
feat(learn): add Claude-session source + first-class no-update advisory

### DIFF
--- a/agents/feedback-learner.md
+++ b/agents/feedback-learner.md
@@ -1,6 +1,6 @@
 ---
 name: feedback-learner
-description: "Analyzes a feedback signal (merged PR, /deliver run, branch diff, or free-form text) against a workspace's current durable context docs, and proposes scoped updates. Read-only — outputs a structured list of findings (tier-classified with before/after diffs) that the /pipecrew:learn skill presents for user approval. Never edits files; never proposes plugin-level file edits.\n\nInputs the caller must provide:\n- source_mode: one of `pr` / `run` / `branch` / `text`\n- identifier: PR URL / run_id / branch name / or first 60 chars of the text\n- signal: the collected raw material for this source (review comments + commits, or run outputs + corrections, or diff, or verbatim text)\n- workspace_slug: which workspace this feedback applies to\n- workspace_config_path: absolute path to the workspace's config.json (for repo list + types)\n- optional_note: user annotation (if the caller passed --note)"
+description: "Analyzes a feedback signal (merged PR, /deliver run, branch diff, Claude Code session, or free-form text) against a workspace's current durable context docs, and proposes scoped updates. Read-only — outputs a structured list of findings (tier-classified with before/after diffs) that the /pipecrew:learn skill presents for user approval. Never edits files; never proposes plugin-level file edits.\n\nInputs the caller must provide:\n- source_mode: one of `pr` / `run` / `branch` / `session` / `text`\n- identifier: PR URL / run_id / branch name / or first 60 chars of the text\n- signal: the collected raw material for this source (review comments + commits, or run outputs + corrections, or diff, or verbatim text)\n- workspace_slug: which workspace this feedback applies to\n- workspace_config_path: absolute path to the workspace's config.json (for repo list + types)\n- optional_note: user annotation (if the caller passed --note)"
 tools: Read, Glob, Grep, Bash
 model: sonnet
 ---
@@ -27,7 +27,8 @@ The caller's prompt embeds everything you need — do not fetch further sources 
 - **`pr` mode**: review comments (delivered as a canonical, pre-numbered `pr-comments.json` — read it; its `C-n` ids are your inventory spine per Step 3.5), plugin commits, post-plugin fix commits. Post-plugin fixes are the richest: they show the truth shipped. Review comments are the second-richest: they show what a human explicitly flagged. Plugin commits are the baseline (what you're comparing against).
 - **`run` mode**: the run's scratchpad, corrections file, phase outputs. Signal comes from (a) the corrections file (user pushbacks during gates) and (b) deltas between initial and final phase outputs.
 - **`branch` mode**: raw `git log` + `git diff`. Weakest structured mode — no separation between plugin vs human commits, no review comments. You're inferring patterns from the diff alone.
-- **`text` mode**: just the user's prose. Often opinionated and specific. Treat the user as the domain expert for what they're saying — they know why the plugin was wrong.
+- **`session` mode**: a canonical, pre-numbered `session.json` of the human turns from a Claude Code conversation (read it; its `C-n` ids are your inventory spine per Step 3.5). **Weakest signal class** — a session is exploratory: most turns are normal back-and-forth, dead ends, or one-off decisions, NOT reusable conventions. Default each turn to `run-local` / `already-satisfied`; only produce a durable finding when a turn reveals a **structural, repeatable** convention the user clearly wants applied beyond this one conversation. When in genuine doubt, recommend no change and say why.
+- **`text` mode**: just the user's prose. Often opinionated and specific. Treat the user as the domain expert for what they're saying — they know why the plugin was wrong. Like `session`, lean toward no durable change unless the prose names a repeatable rule.
 
 ### 2. Load the workspace's current durable docs
 
@@ -107,6 +108,10 @@ Emit your findings in this exact structure (the caller parses it):
 
 ```markdown
 # Feedback analysis — {source identifier}
+
+## Recommendation
+{update | no-update} — {one sentence. `no-update` is a complete, successful answer:
+say WHY nothing durable should change. `update`: name how many durable findings follow.}
 
 ## Summary
 - **Source**: {mode} / {identifier}
@@ -213,6 +218,7 @@ Low-confidence findings are still valuable — they flag candidates for the user
 
 ## You are not done until
 
+- **The top-level `## Recommendation` line is present** stating `update` or `no-update` with a one-sentence reason (for `session` / `text`, `no-update` is the expected default unless a repeatable convention clearly emerged)
 - **Every inventoried comment `C-n` has exactly one disposition and appears as exactly one row in the Comment coverage table** — this is the completeness guard; an unmapped comment is a defect, not an omission you may make silently
 - The coverage check line states ALL COMMENTS COVERED (or names the unmapped ids — only acceptable if you genuinely could not, and then each is flagged for human judgment, never dropped)
 - Every meaningful pattern in the signal has produced a finding

--- a/scripts/collect-session-feedback.js
+++ b/scripts/collect-session-feedback.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * collect-session-feedback.js — extract the human feedback spine from a Claude
+ * Code session transcript (.jsonl) and normalize it into a canonical,
+ * pre-numbered list the feedback-learner builds its C-n inventory from.
+ *
+ * WHY A SCRIPT (not inline parsing in the skill): same reason as
+ * collect-pr-feedback.js — the /learn completeness guard is only as reliable as
+ * the list it validates against. A session transcript is mostly noise
+ * (assistant turns, tool results, local-command stdout, system reminders,
+ * sub-agent sidechains). If the orchestrator hand-walked the JSONL a real user
+ * turn could be missed BEFORE the inventory step runs. This script keeps only
+ * genuine human turns, drops the noise into an audit list, and assigns stable
+ * ids (C-1, C-2, …) so "did we cover every turn?" is a mechanical count. Same
+ * shape family as collect-pr-feedback.js: read → normalize → write a file the
+ * agent Reads (the full bodies stay out of orchestrator context).
+ *
+ * Usage:
+ *   node collect-session-feedback.js --session=<path-to.jsonl> [--out=<file>]
+ *   node collect-session-feedback.js --session=<session-id> [--projects-dir=<dir>] [--out=<file>]
+ *   node collect-session-feedback.js --input=<lines.json> [--out=<file>]   # offline test hook
+ *
+ * --session : a transcript path (ends .jsonl or contains a path separator), OR a
+ *             bare session id resolved against {projects-dir}/{any}/{id}.jsonl.
+ *             ('current' is handled by the /learn skill itself, not here.)
+ * --projects-dir : override the Claude projects root (default ~/.claude/projects).
+ * --out     : write the canonical JSON here + print a one-line summary to stdout.
+ *             Omit to print the canonical JSON to stdout instead.
+ * --input   : read a JSON array of raw transcript line objects from this file
+ *             INSTEAD of touching the filesystem. Lets normalization be
+ *             exercised offline (used by the test).
+ *
+ * Exit 0 success · 1 usage error / file-or-id not found / ambiguous id
+ *        · 3 unparseable transcript (no line parsed).
+ *
+ * Zero dependencies — pure Node stdlib.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function arg(name) {
+  const p = `--${name}=`;
+  const a = process.argv.find((x) => x.startsWith(p));
+  return a ? a.slice(p.length) : null;
+}
+
+// ---- pure normalization (no I/O) — the testable core ------------------------
+
+// A user line whose cleaned text starts with one of these is a slash-command /
+// local-command echo, not human feedback.
+const COMMAND_WRAPPER_RE =
+  /^<(command-name|command-message|command-args|command-contents|local-command-stdout|local-command-caveat)\b/;
+
+function stripReminders(text) {
+  // Harness-injected <system-reminder> blocks are not the user's words.
+  return text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '').trim();
+}
+
+/**
+ * Pull the human-authored text out of a user message's `content`.
+ * @returns { text, hadText, hadToolResult }
+ */
+function extractText(content) {
+  if (typeof content === 'string') {
+    return { text: content, hadText: content.trim().length > 0, hadToolResult: false };
+  }
+  if (Array.isArray(content)) {
+    const texts = [];
+    let hadToolResult = false;
+    for (const b of content) {
+      if (!b || typeof b !== 'object') continue;
+      if (b.type === 'text' && typeof b.text === 'string') texts.push(b.text);
+      else if (b.type === 'tool_result') hadToolResult = true;
+    }
+    const text = texts.join('\n').trim();
+    return { text, hadText: texts.length > 0, hadToolResult };
+  }
+  return { text: '', hadText: false, hadToolResult: false };
+}
+
+/**
+ * @param {object[]} lines parsed transcript line objects, in transcript order
+ * @returns canonical { session, counts, comments, excluded }
+ */
+function normalize(lines) {
+  const comments = [];
+  const excluded = [];
+  let seq = 0;
+  let sessionId = null;
+  let total = 0;
+
+  const drop = (reason, snippet) =>
+    excluded.push({ reason, snippet: (snippet || '').slice(0, 80) });
+
+  for (const line of Array.isArray(lines) ? lines : []) {
+    if (!line || typeof line !== 'object') continue;
+    total++;
+    if (!sessionId && line.sessionId) sessionId = line.sessionId;
+
+    // Only user lines are feedback candidates. Everything else (assistant, mode,
+    // system, attachment, file, create, …) is skipped silently — counting
+    // hundreds of assistant turns as "excluded" would bury the meaningful drops.
+    if (line.type !== 'user') continue;
+
+    // Sub-agent traffic and harness-injected meta turns are not the user talking.
+    if (line.isSidechain === true) { drop('sidechain'); continue; }
+    if (line.isMeta === true) { drop('meta'); continue; }
+    if (line.isCompactSummary === true) { drop('compact-summary'); continue; }
+
+    const msg = line.message;
+    if (!msg || msg.role !== 'user') { drop('non-user-message'); continue; }
+
+    const { text, hadText, hadToolResult } = extractText(msg.content);
+    if (!hadText && hadToolResult) { drop('tool-result'); continue; }
+    if (!hadText) { drop('no-text'); continue; }
+
+    const cleaned = stripReminders(text);
+    if (!cleaned) { drop('system-reminder', text); continue; }
+    if (COMMAND_WRAPPER_RE.test(cleaned)) { drop('local-command', cleaned); continue; }
+
+    seq++;
+    comments.push({
+      id: `C-${seq}`,
+      kind: 'user-turn',
+      ts: line.timestamp || null,
+      body: cleaned,
+    });
+  }
+
+  return {
+    session: { id: sessionId, path: null, turns: comments.length },
+    counts: { signal: comments.length, excluded: excluded.length, lines: total },
+    comments,
+    excluded,
+  };
+}
+
+// ---- filesystem helpers (production path) -----------------------------------
+
+function fail(msg, code) {
+  console.error(msg);
+  process.exit(code);
+}
+
+function readJsonl(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    fail(`transcript not readable: ${file} (${e.message})`, 1);
+  }
+  const out = [];
+  let seen = 0;
+  for (const ln of raw.split(/\r?\n/)) {
+    const s = ln.trim();
+    if (!s) continue;
+    seen++;
+    try {
+      out.push(JSON.parse(s));
+    } catch {
+      // Tolerate an individual malformed line (a trailing partial write is
+      // possible on an append-only transcript) — skip it and keep going.
+    }
+  }
+  if (seen > 0 && out.length === 0) {
+    fail(`could not parse any JSON line from transcript: ${file}`, 3);
+  }
+  return out;
+}
+
+function resolveSessionFile(value, projectsDirArg) {
+  // Explicit transcript path.
+  if (value.endsWith('.jsonl') || value.includes('/') || value.includes('\\')) {
+    if (!fs.existsSync(value)) fail(`transcript file not found: ${value}`, 1);
+    return value;
+  }
+  // Otherwise treat as a bare session id under the Claude projects root.
+  const base = projectsDirArg || path.join(os.homedir(), '.claude', 'projects');
+  if (!fs.existsSync(base)) {
+    fail(`Claude projects dir not found: ${base} (pass --projects-dir or a transcript path)`, 1);
+  }
+  const matches = [];
+  for (const d of fs.readdirSync(base)) {
+    const f = path.join(base, d, `${value}.jsonl`);
+    if (fs.existsSync(f)) matches.push(f);
+  }
+  if (matches.length === 0) fail(`no transcript found for session id "${value}" under ${base}`, 1);
+  if (matches.length > 1) {
+    fail(`session id "${value}" is ambiguous — matched ${matches.length} transcripts:\n  ${matches.join('\n  ')}`, 1);
+  }
+  return matches[0];
+}
+
+// ---- main -------------------------------------------------------------------
+
+function main() {
+  const out = arg('out');
+  const input = arg('input');
+  const session = arg('session');
+  const projectsDir = arg('projects-dir');
+
+  let lines;
+  let sourcePath = null;
+
+  if (input) {
+    if (!fs.existsSync(input)) fail(`input file not found: ${input}`, 1);
+    let parsed;
+    try {
+      parsed = JSON.parse(fs.readFileSync(input, 'utf8'));
+    } catch (e) {
+      fail(`could not parse --input as JSON: ${e.message}`, 3);
+    }
+    lines = Array.isArray(parsed) ? parsed : (Array.isArray(parsed.lines) ? parsed.lines : null);
+    if (!lines) fail('--input must be a JSON array of transcript line objects (or { "lines": [...] })', 1);
+  } else if (session) {
+    if (session === 'current') {
+      fail("'--session=current' is handled by the /learn skill, not this collector — pass a transcript path or a session id.", 1);
+    }
+    sourcePath = resolveSessionFile(session, projectsDir);
+    lines = readJsonl(sourcePath);
+  } else {
+    fail('usage: collect-session-feedback.js --session=<path|id> | --input=<lines.json> [--projects-dir=<dir>] [--out=<file>]', 1);
+  }
+
+  const result = normalize(lines);
+  if (sourcePath) result.session.path = sourcePath;
+  const json = JSON.stringify(result);
+
+  if (out) {
+    fs.mkdirSync(path.dirname(out), { recursive: true });
+    fs.writeFileSync(out, json);
+    const c = result.counts;
+    const range = c.signal > 0 ? ` (C-1..C-${c.signal})` : '';
+    console.log(
+      `wrote ${c.signal} user turns${range} to ${out} ` +
+      `[excluded=${c.excluded} non-feedback, scanned=${c.lines} lines]`
+    );
+  } else {
+    process.stdout.write(json);
+  }
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { normalize, extractText, stripReminders, resolveSessionFile };
+}

--- a/scripts/collect-session-feedback.test.js
+++ b/scripts/collect-session-feedback.test.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for collect-session-feedback.js.
+ * Zero deps: run with `node collect-session-feedback.test.js`.
+ *
+ * The filesystem path (reading a real ~/.claude/projects transcript) is exercised
+ * via a temp transcript + --projects-dir override. The normalization core — where
+ * stable-id assignment, ordering, and noise filtering live — is driven through the
+ * `--input=<lines.json>` hook and tested directly via module.exports.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, 'collect-session-feedback.js');
+const { normalize, extractText, stripReminders } = require('./collect-session-feedback.js');
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'collect-session-feedback-test-'));
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`  ok  ${name}`); passed++; }
+  catch (e) { console.error(`  FAIL ${name}\n       ${e.message}`); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed'); }
+
+let counter = 0;
+function writeLines(lines) {
+  const filePath = path.join(TMP, `lines-${counter++}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(lines));
+  return filePath;
+}
+
+function runInput(lines, ...extra) {
+  const file = writeLines(lines);
+  const r = spawnSync('node', [SCRIPT, `--input=${file}`, ...extra], { encoding: 'utf8' });
+  return { exitCode: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+// ---- fixtures ---------------------------------------------------------------
+
+// A realistic mix: meta lines, real user turns, an assistant turn, a tool-result
+// user message, a local-command echo, a system-reminder-only turn, and a
+// sub-agent sidechain user line.
+function sampleLines() {
+  return [
+    { type: 'mode', mode: 'normal', sessionId: 'S1' },
+    { type: 'permission-mode', permissionMode: 'default', sessionId: 'S1' },
+    // real user turn (string content)
+    { type: 'user', sessionId: 'S1', timestamp: '2026-07-01T10:00:00Z',
+      message: { role: 'user', content: 'we always want a modal, not a separate route' } },
+    // assistant turn — not a candidate
+    { type: 'assistant', sessionId: 'S1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Got it.' }] } },
+    // tool-result user message — excluded
+    { type: 'user', sessionId: 'S1',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] } },
+    // real user turn carrying a leading system-reminder that must be stripped
+    { type: 'user', sessionId: 'S1', timestamp: '2026-07-01T10:05:00Z',
+      message: { role: 'user', content: '<system-reminder>ambient</system-reminder>\nnever split publisher modules' } },
+    // system-reminder-ONLY user turn — excluded
+    { type: 'user', sessionId: 'S1',
+      message: { role: 'user', content: '<system-reminder>just context</system-reminder>' } },
+    // local-command echo — excluded
+    { type: 'user', sessionId: 'S1',
+      message: { role: 'user', content: '<command-name>/compact</command-name>\n<command-message>compact</command-message>' } },
+    // sub-agent sidechain user line — excluded
+    { type: 'user', sessionId: 'S1', isSidechain: true,
+      message: { role: 'user', content: 'sub-agent prompt' } },
+    // compact summary user line — excluded
+    { type: 'user', sessionId: 'S1', isCompactSummary: true,
+      message: { role: 'user', content: 'big summary blob' } },
+    // real user turn (array content with a text block)
+    { type: 'user', sessionId: 'S1', timestamp: '2026-07-01T10:10:00Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'prefer Specification queries over raw JPQL' }] } },
+  ];
+}
+
+// ---- normalize() core -------------------------------------------------------
+
+test('keeps only genuine user turns, numbers them C-1..C-n in transcript order', () => {
+  const r = normalize(sampleLines());
+  assert(r.comments.length === 3, `expected 3 user turns, got ${r.comments.length}`);
+  assert(r.comments.map((c) => c.id).join(',') === 'C-1,C-2,C-3', 'ids not sequential');
+  assert(r.comments[0].body.includes('modal'), 'turn 1 wrong / out of order');
+  assert(r.comments[1].body === 'never split publisher modules', 'reminder not stripped from turn 2');
+  assert(r.comments[2].body.includes('Specification'), 'array-content turn not captured');
+});
+
+test('every comment is kind user-turn and carries its timestamp', () => {
+  const r = normalize(sampleLines());
+  assert(r.comments.every((c) => c.kind === 'user-turn'), 'wrong kind');
+  assert(r.comments[0].ts === '2026-07-01T10:00:00Z', 'timestamp not carried');
+});
+
+test('routes tool-results / reminders / local-commands / sidechain / compact into excluded', () => {
+  const r = normalize(sampleLines());
+  const reasons = r.excluded.map((e) => e.reason).sort();
+  assert(reasons.includes('tool-result'), 'tool-result not excluded');
+  assert(reasons.includes('system-reminder'), 'reminder-only not excluded');
+  assert(reasons.includes('local-command'), 'local-command not excluded');
+  assert(reasons.includes('sidechain'), 'sidechain not excluded');
+  assert(reasons.includes('compact-summary'), 'compact summary not excluded');
+});
+
+test('assistant + mode lines are skipped silently, not counted as excluded', () => {
+  const r = normalize(sampleLines());
+  // 5 dropped user lines above; assistant/mode lines must NOT inflate this.
+  assert(r.counts.excluded === 5, `expected 5 excluded user turns, got ${r.counts.excluded}`);
+});
+
+test('captures sessionId from the transcript', () => {
+  const r = normalize(sampleLines());
+  assert(r.session.id === 'S1', `session id wrong: ${r.session.id}`);
+  assert(r.session.turns === 3, 'turns count wrong');
+});
+
+test('id assignment is deterministic across repeated runs', () => {
+  const a = normalize(sampleLines());
+  const b = normalize(sampleLines());
+  assert(JSON.stringify(a.comments) === JSON.stringify(b.comments), 'non-deterministic output');
+});
+
+test('empty / non-array input yields zero comments, not a crash', () => {
+  assert(normalize([]).comments.length === 0, 'empty array handling wrong');
+  assert(normalize(null).comments.length === 0, 'null handling wrong');
+});
+
+// ---- helpers ----------------------------------------------------------------
+
+test('stripReminders removes system-reminder blocks anywhere in the text', () => {
+  assert(stripReminders('<system-reminder>x</system-reminder>\nhello') === 'hello');
+  assert(stripReminders('a<system-reminder>x</system-reminder>b').replace(/\s/g, '') === 'ab');
+});
+
+test('extractText pulls text blocks and flags tool-result-only content', () => {
+  assert(extractText('hi').hadText === true);
+  const tr = extractText([{ type: 'tool_result', content: 'x' }]);
+  assert(tr.hadText === false && tr.hadToolResult === true, 'tool-result detection wrong');
+});
+
+// ---- CLI surface ------------------------------------------------------------
+
+test('CLI: --input + --out writes canonical JSON and prints a one-line summary', () => {
+  const file = writeLines(sampleLines());
+  const outPath = path.join(TMP, 'out.json');
+  const r = spawnSync('node', [SCRIPT, `--input=${file}`, `--out=${outPath}`], { encoding: 'utf8' });
+  assert(r.status === 0, `exit ${r.status}; stderr: ${r.stderr}`);
+  assert(r.stdout.trim().split('\n').length === 1, 'summary should be one line');
+  assert(r.stdout.includes('C-1..C-3'), `summary missing id range: ${r.stdout}`);
+  const written = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  assert(written.comments.length === 3, 'written file comment count wrong');
+});
+
+test('CLI: --input without --out prints canonical JSON to stdout', () => {
+  const r = runInput(sampleLines());
+  assert(r.exitCode === 0, `exit ${r.exitCode}; stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert(out.comments[0].id === 'C-1', 'stdout JSON malformed');
+});
+
+test('CLI: --session resolves a real .jsonl transcript path', () => {
+  const jsonl = sampleLines().map((l) => JSON.stringify(l)).join('\n') + '\n';
+  const tFile = path.join(TMP, 'real-transcript.jsonl');
+  fs.writeFileSync(tFile, jsonl);
+  const r = spawnSync('node', [SCRIPT, `--session=${tFile}`], { encoding: 'utf8' });
+  assert(r.status === 0, `exit ${r.status}; stderr: ${r.stderr}`);
+  const out = JSON.parse(r.stdout);
+  assert(out.comments.length === 3, 'transcript path parse wrong');
+  assert(out.session.path === tFile, 'session.path not set');
+});
+
+test('CLI: --session resolves a bare session id under --projects-dir', () => {
+  const projDir = path.join(TMP, 'projects');
+  const sub = path.join(projDir, 'some-encoded-cwd');
+  fs.mkdirSync(sub, { recursive: true });
+  const jsonl = sampleLines().map((l) => JSON.stringify(l)).join('\n') + '\n';
+  fs.writeFileSync(path.join(sub, 'ABC-123.jsonl'), jsonl);
+  const r = spawnSync('node', [SCRIPT, '--session=ABC-123', `--projects-dir=${projDir}`], { encoding: 'utf8' });
+  assert(r.status === 0, `exit ${r.status}; stderr: ${r.stderr}`);
+  assert(JSON.parse(r.stdout).comments.length === 3, 'id resolution parse wrong');
+});
+
+test('CLI: exit 1 when a session id is not found', () => {
+  const projDir = path.join(TMP, 'projects');
+  const r = spawnSync('node', [SCRIPT, '--session=does-not-exist', `--projects-dir=${projDir}`], { encoding: 'utf8' });
+  assert(r.status === 1, `expected 1, got ${r.status}`);
+});
+
+test('CLI: exit 1 when --session=current (handled by the skill, not the collector)', () => {
+  const r = spawnSync('node', [SCRIPT, '--session=current'], { encoding: 'utf8' });
+  assert(r.status === 1, `expected 1, got ${r.status}`);
+});
+
+test('CLI: exit 1 on usage error (no source args)', () => {
+  const r = spawnSync('node', [SCRIPT], { encoding: 'utf8' });
+  assert(r.status === 1, `expected 1, got ${r.status}`);
+});
+
+test('CLI: exit 3 on malformed --input JSON', () => {
+  const bad = path.join(TMP, 'bad.json');
+  fs.writeFileSync(bad, '{ not valid json ');
+  const r = spawnSync('node', [SCRIPT, `--input=${bad}`], { encoding: 'utf8' });
+  assert(r.status === 3, `expected 3, got ${r.status}`);
+});
+
+// Cleanup
+fs.rmSync(TMP, { recursive: true, force: true });
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/redact-secrets.js
+++ b/scripts/redact-secrets.js
@@ -114,8 +114,13 @@ const RULES = [
     kind: 'token',
     // Charset deliberately EXCLUDES path separators (. / -) so dotted/slashed/
     // hyphenated code identifiers and paths split into short harmless segments.
-    // Underscore and base64 chars (+/=) are kept (real secrets use them).
-    re: /(?<![A-Za-z0-9_+/=~])([A-Za-z0-9_+/=~]{20,})(?![A-Za-z0-9_+/=~])/g,
+    // NOTE: '/' MUST stay out of this class — including it makes long slash-paths
+    // (e.g. /v1/publishers/publishers/user/) and slash-joined enum lists
+    // (PASSED_LEVEL_1/2/3) match, and isCredentialish()'s base64ish test then
+    // flags the lone '/' as a secret. Keep underscore + base64 padding chars
+    // (+ = ~) only; real base64 secrets also carry mixed case / length and are
+    // caught by isCredentialish without needing '/'.
+    re: /(?<![A-Za-z0-9_+=~])([A-Za-z0-9_+=~]{20,})(?![A-Za-z0-9_+=~])/g,
     replace: (full, tok) => (isCredentialish(tok) ? '[REDACTED-token]' : full),
   },
 ];

--- a/scripts/sync-memory.js
+++ b/scripts/sync-memory.js
@@ -126,7 +126,15 @@ if (DRY) {
   console.log(`sync-memory: --dry-run (mode=${syncMode}), would commit:\n` + (st.stdout || '(no changes)'));
   process.exit(0);
 }
-git(['add', '-A']);
+// Stage an explicit ALLOW-LIST of durable-doc paths only — never `git add -A`.
+// A deny-list (.gitignore) can't anticipate arbitrary junk a user may drop in the
+// workspace dir (e.g. a "copy of claude code session/" transcript dump), and such
+// content would otherwise be committed UN-redacted (redaction only runs over
+// context/agents/history). Allow-listing guarantees only known docs are published.
+const ALLOW = ['context', 'agents', 'history', 'config.portable.json', '.gitignore'];
+const toStage = ALLOW.filter((rel) => fs.existsSync(path.join(wsDir, rel)));
+// `-A` scoped to each pathspec so deletions within the durable dirs are captured too.
+if (toStage.length) git(['add', '-A', '--', ...toStage]);
 const staged = git(['diff', '--cached', '--name-only']).stdout.trim();
 if (!staged) { console.log('sync-memory: nothing changed — no commit'); process.exit(0); }
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn
-description: "Learn from user feedback about a shipped feature — from a merged PR, a recorded /deliver run, a branch diff, or free-form text — and propose scoped updates to the workspace's durable context docs (platform.md § Established Patterns, repo CLAUDE.md / DESIGN_SYSTEM.md / agent-context/). Presents findings tier-classified (repo / workspace / plugin-level) with before/after diffs; user approves per finding; approved changes are applied. After the docs are saved the user can optionally dispatch the per-repo implementer agents to apply the same findings to an existing branch as a fix round (so the branch the feedback came from gets brought in line with the new conventions, not just future work). Every run is logged to history/learn-log.md for institutional memory."
+description: "Learn from user feedback — from a merged PR, a recorded /deliver run, a branch diff, a Claude Code session transcript, or free-form text — and propose scoped updates to the workspace's durable context docs (platform.md § Established Patterns, repo CLAUDE.md / DESIGN_SYSTEM.md / agent-context/). Presents findings tier-classified (repo / workspace / plugin-level) with before/after diffs; user approves per finding; approved changes are applied. After the docs are saved the user can optionally dispatch the per-repo implementer agents to apply the same findings to an existing branch as a fix round (so the branch the feedback came from gets brought in line with the new conventions, not just future work). Every run is logged to history/learn-log.md for institutional memory."
 ---
 
 ## Description
@@ -11,7 +11,10 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 - Merged PR (GitHub via `gh` CLI) — reads review comments + post-plugin fix commits to learn from what humans had to correct
 - Recorded /deliver run — reads `corrections.md` + the run's outputs to learn from what the user had to push back on during dispatch
 - Branch diff — reads a diff between a branch and its base, no PR required
+- **Claude Code session** — a conversation transcript (a `.jsonl` under `~/.claude/projects/.../{sessionId}.jsonl`, or the live session via `--session=current`). Learns from what the user steered, corrected, or repeated across a working session. **No prior /deliver run required** — point it at any session and it reasons about whether anything is worth persisting.
 - Free-form text — conversational user feedback from any channel
+
+> **Session / free-form text are the weakest signal class** — they are *exploratory* (most of a session is normal work, not a reusable rule). `/learn` biases hard toward "no update" for these: it lists what it noticed and recommends a context change **only** when a structural, repeatable convention is revealed. A clear "no change recommended, here's why" is a first-class, successful outcome — not a failed run.
 
 **Output scopes** (tier classification for every finding):
 - **Workspace durable** → updates `{workspace_root}/{slug}/context/platform.md` (typically the `Established Patterns` section)
@@ -31,6 +34,7 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 /pipecrew:learn --pr=<url> [--note="..."] [--workspace=<slug>]
 /pipecrew:learn --run=<run_id> [--workspace=<slug>]
 /pipecrew:learn --branch=<name> [--base=<main>] [--workspace=<slug>]
+/pipecrew:learn --session=<path|id|current> [--note="..."] --workspace=<slug>
 /pipecrew:learn "<free-form text>" [--workspace=<slug>]
 
 # Optional fix-round flags (combine with any source mode above):
@@ -48,6 +52,7 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 | `--run=<run_id>` | A `/deliver` run directory name under `{workspace_root}/{slug}/runs/feature/`. Reads that run's `corrections.md` + outputs. |
 | `--branch=<name>` | Branch name to diff (local). Base defaults to `main` or `dev` — whichever the workspace uses. |
 | `--base=<name>` | Override the base branch for `--branch` mode. |
+| `--session=<path\|id\|current>` | Learn from a Claude Code session. `current` = the live conversation (the orchestrator distills its salient feedback turns); a `.jsonl` path or a bare session id = a past transcript (collected via `collect-session-feedback.js`). Weakest signal class — see the source-reliability note. Composes with `--note` (that **is** the "free text + session" combination — no separate flag needed). Requires `--workspace` (no repo to auto-detect from). |
 | `--workspace=<slug>` | Which workspace's docs to update. Auto-detects if omitted (scans `{workspace_root}/*/config.json` for repo paths that match the PR / branch). |
 | `--dry-run` | Show findings + proposed updates, but skip the apply step. Implies `--no-fix` (a dry run never dispatches implementers). |
 | `--apply-all` | Skip per-finding approval and apply every non-plugin-level finding. Does NOT imply `--auto-fix` — the fix-round prompt still runs after applies unless `--auto-fix` / `--no-fix` is also passed. |
@@ -62,6 +67,9 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 /pipecrew:learn --pr=https://github.com/.../pull/42 --note="we fixed the auth approach, see commit d28808e"
 /pipecrew:learn --run=2026-04-16-120338-book-content-upload
 /pipecrew:learn --branch=fix/contract-detail-modals --base=main
+/pipecrew:learn --session=current --workspace=dal-platform          # learn from the conversation we just had
+/pipecrew:learn --session=2ed98d97-4d59-4e46-... --workspace=dal-platform   # a past session by id
+/pipecrew:learn --session=current --workspace=dal-platform --note="focus on the modal-vs-route discussion"
 /pipecrew:learn "the plugin keeps putting details in a separate route, we always want a modal"
 
 # With fix-round:
@@ -78,7 +86,7 @@ The learning loop for PipeCrew. Converts one feedback signal → scoped doc upda
 2. **Never auto-apply plugin-level findings.** The target would be the plugin's own prompts/templates, which are shared across all workspaces. Plugin-level findings are logged with the flag `plugin-level-review-needed` so the maintainer can assess.
 3. **Tier classification is the first filter.** Run-local findings are visible in the summary but don't become proposals. Only repo-scope, workspace-scope, and plugin-scope findings become actionable items.
 4. **Log every invocation.** Append to `{workspace_root}/{slug}/history/learn-log.md` — even if every finding was rejected. The record matters.
-5. **Be explicit about source reliability.** PR review comments from a human reviewer are strong signal. Post-merge fix commits are strong signal (the truth shipped). Free-form user text is strong signal but filtered through the user's recall. Run corrections are moderate signal (may have been one-off decisions).
+5. **Be explicit about source reliability.** PR review comments from a human reviewer are strong signal. Post-merge fix commits are strong signal (the truth shipped). Free-form user text is strong signal but filtered through the user's recall. Run corrections are moderate signal (may have been one-off decisions). **A Claude Code session is the weakest signal** — exploratory, mostly normal work, lots of dead ends; treat it the same class as free-form text and default to recommending no change unless a structural, repeatable convention clearly emerges.
 6. **Never dispatch a fix-round implementer without explicit user consent.** The fix round modifies real code on a real branch — it is the only step in `/learn` that touches anything outside the workspace docs. Default behavior is to ask the user (per repo, with the resolved branch named) before each dispatch. Only `--auto-fix` skips that gate, and only after the standard per-finding doc-approval gate has already run. `--dry-run` always implies `--no-fix`. Plugin-level findings never become fix-round dispatches (their target is the plugin, not workspace code).
 
 ---
@@ -106,7 +114,7 @@ If `--workspace=<slug>` is provided, use `{workspace_root}/{slug}/config.json`. 
 
 - For `--pr` / `--branch`: extract the repo path from the PR URL or current working directory. Scan `{workspace_root}/*/config.json` for any workspace whose `repos.*.path` matches. If exactly one matches, use it. If multiple, ask the user.
 - For `--run`: the run ID contains the workspace slug inherently — `{workspace_root}/*/runs/feature/{run_id}/` unique match.
-- For free-form text: no auto-detection possible. If `--workspace` is omitted, ask.
+- For `--session` and free-form text: no repo to auto-detect from. If `--workspace` is omitted, ask.
 
 Validate the resolved config via `node {plugin_dir}/scripts/validate-config.js {config-path}`. Halt on errors.
 
@@ -177,6 +185,31 @@ No PR, no review comments — just the raw diff. Weakest of the structured modes
 
 The signal IS the text. No collection step beyond capturing the user's prompt verbatim. The learner reads it alongside the current tier-1 docs and proposes what the text implies.
 
+#### 2e. Session mode (`--session`)
+
+Learn from a Claude Code conversation. Two sub-cases:
+
+**`--session=<path>` or `--session=<id>`** (a past transcript) — use the canonical collector; do NOT hand-walk the JSONL. The transcript is mostly noise (assistant turns, tool results, local-command stdout, system reminders, sub-agent sidechains) and a real user turn can be missed before the coverage guard sees it. The script keeps only genuine human turns, drops the rest into an audit list, and assigns **stable `C-n` ids** the learner adopts verbatim:
+
+```bash
+node {plugin_dir}/scripts/collect-session-feedback.js --session={path-or-id} --out={run_dir}/signal/session.json
+```
+
+Exit codes: `0` ok · `1` usage / transcript-or-id not found / ambiguous id · `3` unparseable transcript. The script prints only a one-line count to stdout — the turn bodies stay in the file, out of your context. Pass `{run_dir}/signal/session.json` to the learner (Step 3); it Reads the file and builds its `C-n` inventory from the ids already assigned. (A bare id resolves under `~/.claude/projects/*/{id}.jsonl`; pass an absolute `.jsonl` path if the id is ambiguous.)
+
+**`--session=current`** (the live conversation) — you are *in* the session, so do NOT try to self-read the whole transcript (it would blow the context budget). Instead, distill the salient feedback turns from the conversation you are currently in — the corrections, the "no, do it this way", the things the user repeated or insisted on — and write them yourself into `{run_dir}/signal/session.json` in the **same shape the collector emits**:
+
+```json
+{ "session": { "id": "current", "path": null, "turns": N },
+  "counts": { "signal": N, "excluded": 0, "lines": 0 },
+  "comments": [ { "id": "C-1", "kind": "user-turn", "ts": null, "body": "<verbatim or close-paraphrase of one feedback turn>" } ],
+  "excluded": [] }
+```
+
+Keep `comments[]` to the turns that actually carry steering/feedback — skip routine "ok", "continue", "thanks". This is the cheap default path: finish a conversation, run `/learn --session=current`, and it proposes what (if anything) is worth persisting.
+
+Either way, the resulting `session.json` is the signal bundle handed to the learner. Include `--note` verbatim if provided (that is the "free text + session" combination).
+
 ---
 
 ### Step 3: Dispatch the feedback-learner agent
@@ -232,6 +265,24 @@ sub-ids C-n-a / C-n-b for the split.)
 ### User feedback text
 {paste verbatim}
 
+{For session mode:}
+### Session feedback — canonical list (read this file)
+The session's human turns are pre-collected, de-noised, and numbered at:
+  {run_dir}/signal/session.json
+Read that file. Each entry has a stable `C-n` id, `kind: user-turn`, and the turn
+body (assistant turns, tool results, local-command echoes, system reminders and
+sub-agent sidechains are already excluded). **Adopt those `C-n` ids verbatim as
+your inventory spine** (Step 3.5) — do not renumber or drop them. Every `C-n`
+MUST appear in your Comment coverage table with a disposition.
+
+NOTE — this is the **weakest** signal class. A session is exploratory: most turns
+are normal back-and-forth, dead ends, or one-off decisions, NOT reusable
+conventions. Default each turn to `run-local` or `already-satisfied`. Only emit a
+durable (`repo-durable` / `workspace-durable`) finding when a turn reveals a
+**structural, repeatable** convention the user clearly wants applied beyond this
+one conversation (e.g. "we ALWAYS use a modal", "NEVER split publisher modules").
+When in genuine doubt, do NOT propose an update — recommend no change and say why.
+
 ## Current workspace durable docs (read and compare)
 
 Read each of these before proposing any update:
@@ -285,6 +336,12 @@ Per finding, answer:
 
 ```markdown
 # Feedback analysis — {source identifier}
+
+## Recommendation
+{update | no-update} — {one sentence. If no-update, this is a complete, successful
+answer: say WHY nothing durable should change, e.g. "the session was normal
+feature work; no repeatable convention emerged." If update, name how many durable
+findings follow.}
 
 ## Summary
 - Source: {mode} / {identifier}
@@ -350,7 +407,11 @@ Per finding, answer:
    the workspace level applies to future repos of the same type too.
 4. **If the signal is weak or ambiguous, say so.** Mark low-confidence findings
    with "Confidence: low" and explain why. A finding with weak evidence is
-   better rejected than forced.
+   better rejected than forced. For `session` / free-form `text` sources,
+   default to **no durable finding** — these are exploratory, and recommending
+   "no change" with a clear reason is a correct, complete answer, not a failure.
+   Always emit the top-level `## Recommendation` line stating `update` or
+   `no-update`.
 5. **No file edits.** You propose, the orchestrator applies after user
    approval. Do NOT use Write or Edit tools.
 6. **No plugin-level edits.** Even if a finding is clearly plugin-level,
@@ -393,6 +454,7 @@ Code-fix items (`CF-n`) are carried into the Step 6.5 fix-round bundles (the "as
 ```
 ## Feedback findings — {source}
 
+Recommendation: {update | no-update} — {the learner's one-sentence justification}
 Signal strength: {strong|moderate|weak}
 Workspace-durable: {N}   Repo-durable: {N}   Plugin-level (flagged): {N}   Run-local (FYI): {N}
 
@@ -432,6 +494,8 @@ For `run-local` findings, do not prompt at all — just list them in the summary
 Batch mode (`--apply-all`): skip per-finding prompts, show a combined summary + one confirmation. Reject-per-finding is not available in this mode.
 
 Dry-run mode (`--dry-run`): show findings + proposed changes, emit a single "would apply N findings" summary, skip both apply AND log write. Nothing persists.
+
+**No actionable findings (common for `session` / `text`):** if the learner's `## Recommendation` is `no-update` and there are zero repo/workspace/plugin findings, skip the per-finding prompts entirely. Still write the learn-log entry (Step 6) — the reasoning is worth keeping — and go straight to the Step 7 summary, rendering it as the positive "no change recommended" outcome, not a warning. There is nothing to apply and (unless `--fix-branch` was given) no fix round.
 
 ---
 
@@ -535,6 +599,7 @@ Doc updates from Step 5 only steer **future** runs. The branch the feedback came
 - `--dry-run` was passed (no docs were applied either, so there's nothing to "match" the branch to).
 - Zero findings were applied at Step 5 **AND** the learner produced zero `code-fix` (CF-n) items (nothing to fix in code).
 - Every applied finding is `plugin-level` **AND** there are no CF-n items (no workspace repo to fix).
+- The source is `session` or free-form `text` **AND** `--fix-branch` was not passed. A session/text signal need not correspond to any branch, so the fix round is **opt-in** for these sources: run it only when the user explicitly names the branch to bring in line via `--fix-branch`. (With `--fix-branch`, proceed normally.)
 
 > **Code-fix items are first-class fix-round input.** The fix round addresses two kinds of work: (a) approved doc findings whose convention the branch still violates, and (b) the learner's `code-fix` (CF-n) items — real defects a reviewer flagged that aren't reusable conventions. Both flow through the same per-repo bundling below. CF-n items make the round worth running even when every doc finding was rejected.
 
@@ -689,7 +754,17 @@ Emit the standard one-line phase-done status. Include a fix-round suffix when St
 
 Always print the coverage line — it is the at-a-glance proof that no reviewer comment was silently dropped. If coverage is < 100%, use ⚠ and name the unmapped ids.
 
-If no findings were applied AND no fix-round ran, use ⚠:
+**No durable change — distinguish deliberate from incomplete.** When 0 findings were applied:
+
+- If the learner's `## Recommendation` was `no-update` (it looked and concluded nothing reusable emerged — the common, *correct* outcome for `session` / `text`), render it as a clean ✔ with the recommendation as the headline. This is a successful run, not a warning:
+
+```
+[feedback ✔] no context change recommended — session "modal-vs-route" (1:48, 12k tokens)
+  Looked at 9 turns; all run-local (normal feature work). Reasoning recorded in learn-log.md.
+  ↳ coverage: 9/9 turns dispositioned
+```
+
+- If findings WERE proposed but the user rejected them all (or coverage is incomplete), keep the ⚠ — something actionable was surfaced and nothing landed:
 
 ```
 [feedback ✔⚠] 0 applied, 4 rejected, 1 plugin-flagged — PR #31 (2:15, 18k tokens)
@@ -767,6 +842,6 @@ Every `/pipecrew:learn` run emits the same event schema as `/deliver` / `/discov
 - `phase_end` — one per pipeline step above. Step 6.5 emits its own `phase_end` only when at least one bundle was dispatched; otherwise a skip-reason is recorded as `phase_end` with `status: "skipped"` and `reason` set to one of `no-fix-flag` / `dry-run` / `no-applied-findings` / `all-plugin-level` / `user-declined`.
 - `run_end` — with applied/rejected/flagged counts AND fix-round counts (`fix_repos`, `fix_findings_applied`, `fix_findings_skipped`).
 
-Run directory: `{workspace_root}/{slug}/runs/learn/{run_id}/` where `{run_id}` = `{YYYY-MM-DD-HHMMSS}-{source-slug}`. `source-slug` = `pr-31`, `run-2026-04-16-xxx`, `branch-fix-foo`, or `text` (truncated first 24 chars of text).
+Run directory: `{workspace_root}/{slug}/runs/learn/{run_id}/` where `{run_id}` = `{YYYY-MM-DD-HHMMSS}-{source-slug}`. `source-slug` = `pr-31`, `run-2026-04-16-xxx`, `branch-fix-foo`, `session-current` or `session-{id-prefix}` (first 8 chars of the session id), or `text` (truncated first 24 chars of text).
 
 Keep the learner's raw output under `{run_dir}/learner-output.md` for post-hoc debugging. The log entry is the human-facing summary; the raw output is the full reasoning trail.

--- a/templates/workspace-memory.gitignore
+++ b/templates/workspace-memory.gitignore
@@ -1,29 +1,31 @@
 # pipecrew workspace memory repo — .gitignore
-# Versions the DURABLE workspace memory (context/, agents/, history/,
-# config.portable.json). Everything below is local-only / machine-specific /
-# run noise and must NOT be pushed. See docs/design/github-memory.md.
+# ALLOW-LIST by design: ignore everything, then un-ignore ONLY the durable
+# workspace memory (context/, agents/, history/, config.portable.json).
+# This is defense-in-depth alongside sync-memory.js's allow-listed `git add`:
+# anything a user drops into the workspace dir (e.g. a "copy of claude code
+# session/" transcript dump, scratch files, exports) is ignored by default and
+# can never be committed/pushed — even by a stray `git add -A`.
+# See docs/design/github-memory.md.
 
-# --- machine-specific config (absolute repo paths) ---
-config.json
-config.local.json
+# 1. Ignore everything at the root.
+/*
 
-# --- run artifacts (scratchpads, checkpoints, outputs, reports) ---
-# Large + churny; token trends come from the reporter locally, not git.
-runs/
+# 2. Un-ignore the .gitignore itself and the durable-doc paths.
+!/.gitignore
+!/context/
+!/agents/
+!/history/
+!/config.portable.json
 
-# --- transient / in-flight markers ---
-.observability-draft.json
-.in_use/
-awaiting_input.json
-*.autoapprove
-.autoapprove-*
+# 3. Within the un-ignored durable dirs, still exclude transient/in-flight noise.
+context/**/.observability-draft.json
+**/.in_use/
+**/awaiting_input.json
+**/*.autoapprove
+**/.autoapprove-*
 
-# --- local Claude Code settings (may contain machine paths / allow-rules) ---
-.claude/settings.local.json
-.claude/worktrees/
-
-# --- OS / editor cruft ---
-.DS_Store
-Thumbs.db
-*.swp
-*~
+# 4. OS / editor cruft (in case it lands inside a durable dir).
+**/.DS_Store
+**/Thumbs.db
+**/*.swp
+**/*~


### PR DESCRIPTION
## What

Adds `--session=<path|id|current>` as a fourth `/learn` source so the crew can learn from a Claude Code conversation **with no prior `/deliver` run**, and reframes "no change needed" as a first-class, successful outcome.

Most of the original ask already existed (`--pr`, `--branch`, and free-form text all work without a run, and tier-classification already reasons + lists). The two real gaps this closes:

1. **No way to learn from a session.** There was no source mode for a conversation transcript.
2. **"No update" read like a near-miss.** The `0 applied` path rendered as `⚠ No workspace docs updated`.

## How

**New collector — `scripts/collect-session-feedback.js`** (+ `.test.js`, 17 tests)
Mirrors `collect-pr-feedback.js`: pure `normalize()` core, offline `--input` hook, stable `C-n` ids, zero deps. Extracts the human-feedback spine from a transcript, routing assistant turns, tool results, local-command echoes, system reminders, sub-agent sidechains and compaction summaries into an audit list. Resolves `--session=<path>`, a bare session id (globbed under `~/.claude/projects`), or `--input`.

Smoke-tested on a real 4,211-line transcript: **79 human turns extracted, 506 noise lines filtered** (491 tool-results, 6 meta, 6 local-commands, 3 compact-summaries).

**`skills/learn/SKILL.md` + `agents/feedback-learner.md`** — wired into the existing single pipeline (no second skill):
- **Step 2e**: `--session=<path|id>` runs the collector; `--session=current` has the orchestrator distill the live conversation into the same `session.json` shape (avoids self-reading a huge transcript).
- Session/text declared the **weakest signal class** — bias hard toward no change; only persist structural, repeatable conventions.
- First-class **`## Recommendation` (update | no-update)** line; a reasoned "no change" renders as a clean ✔, not a warning.
- Fix-round is **opt-in** for these sources (requires `--fix-branch`).
- `--note` composes with `--session` → that's the "free text + session" combination.

Still works unchanged inside a `/deliver` run (`--run`).

## Verification

- `collect-session-feedback.test.js`: 17/17 ✓ · `collect-pr-feedback.test.js`: 17/17 (no regression) ✓
- `node eval/run.js`: **6/6 files, all layers PASS, exit 0** (harness auto-discovers the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)