### PR TITLE
release: v1.1.0 — site-view v2 (default), canonical stages tail, website logo, update-notify

### DIFF
--- a/skills/site-view/public/icon-tip-hat-3d.svg
+++ b/skills/site-view/public/icon-tip-hat-3d.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="8 -2 48 58" role="img" aria-label="Pipecrew crew member tipping the hat over a 3D pyramid">
+  <style>
+    .s{ fill:none; stroke:#1a1814; stroke-linecap:round; stroke-linejoin:round; }
+    .a{ fill:#c8741b; stroke:none; }
+    .node{ fill:#f3efe7; stroke:#1a1814; stroke-linecap:round; stroke-linejoin:round; }
+    .f1{ fill:#1a1814; }
+    .f2{ fill:#5f5749; }
+  </style>
+  <!-- head -->
+  <circle class="node" stroke-width="2.6" cx="32" cy="27" r="11"/>
+  <!-- hat dome + brim -->
+  <path class="a" d="M20 16 Q20 5 32 4 Q44 5 44 16 Z"/>
+  <rect class="a" x="13" y="14" width="38" height="4.2" rx="2.1"/>
+  <!-- arms + hands tipping the brim -->
+  <line class="s" stroke-width="2.4" x1="23" y1="38" x2="16" y2="30"/>
+  <circle class="node" stroke-width="2" cx="15" cy="27" r="3"/>
+  <line class="s" stroke-width="2.4" x1="41" y1="38" x2="48" y2="30"/>
+  <circle class="node" stroke-width="2" cx="49" cy="27" r="3"/>
+  <!-- 3D pyramid: apex meets the bottom of the head; shadow face left, lit face right -->
+  <path class="f2" d="M32 38 L22 50 L32 54 Z"/>
+  <path class="f1" d="M32 38 L42 50 L32 54 Z"/>
+</svg>

--- a/skills/site-view/public/index-v2.html
+++ b/skills/site-view/public/index-v2.html
@@ -40,8 +40,14 @@
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
+    /* light disc so the logo's dark outlines read on the dark header */
+    background: #f3efe7;
+    border-radius: 50%;
+    padding: 4px;
+    box-shadow: 0 0 0 1px rgba(245,166,35,0.5), 0 2px 8px rgba(0,0,0,0.4);
   }
-  .brand-mark svg { width: 100%; height: 100%; display: block; }
+  .brand-mark svg,
+  .brand-mark img { width: 100%; height: 100%; display: block; }
   .brand-mark .apex-spark {
     transform-box: fill-box;
     transform-origin: center;
@@ -1459,30 +1465,8 @@
 
 <header>
   <div class="brand-mark" aria-label="PipeCrew">
-    <svg viewBox="0 0 40 44" xmlns="http://www.w3.org/2000/svg">
-      <!-- stepped pyramid outline -->
-      <g fill="none" stroke="#f5a623" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round">
-        <path d="M5 30 L20 7 L35 30 Z"/>
-        <line x1="11" y1="21" x2="29" y2="21"/>
-        <line x1="15" y1="14" x2="25" y2="14"/>
-      </g>
-      <!-- apex sun: tiny rays + body (pulsing) -->
-      <g class="apex-spark">
-        <g stroke="#fbbf24" stroke-width="1.2" stroke-linecap="round" fill="none">
-          <line x1="20" y1="2"  x2="20" y2="5"/>
-          <line x1="14.5" y1="4" x2="13"  y2="2.5"/>
-          <line x1="25.5" y1="4" x2="27"  y2="2.5"/>
-        </g>
-        <circle cx="20" cy="7" r="2.1" fill="#fbbf24" stroke="#f5a623" stroke-width="0.9"/>
-      </g>
-      <!-- base pipe + 3 crew dots -->
-      <line x1="5" y1="35" x2="35" y2="35" stroke="#5c4420" stroke-width="1.1" stroke-linecap="round" opacity="0.7"/>
-      <g fill="#f5a623" stroke="#5c4420" stroke-width="0.8">
-        <circle cx="10" cy="35" r="2.2"/>
-        <circle cx="20" cy="35" r="2.6"/>
-        <circle cx="30" cy="35" r="2.2"/>
-      </g>
-    </svg>
+    <!-- Brand logo — same asset as the website (public/icon-tip-hat-3d.svg). -->
+    <img src="/icon-tip-hat-3d.svg" alt="PipeCrew" />
   </div>
   <div>
     <h1><span id="feature-name">Pipeline View</span></h1>

--- a/skills/site-view/server.js
+++ b/skills/site-view/server.js
@@ -1854,6 +1854,20 @@ const server = http.createServer((req, res) => {
       res.writeHead(404);
       res.end(fname + ' not found — re-run the plugin install to vendor it.');
     }
+  } else if (req.url === '/icon-tip-hat-3d.svg') {
+    // Brand logo (matches the website). Served from public/ so the v2 header
+    // can <img> it with its internal styles isolated.
+    try {
+      const svg = fs.readFileSync(path.join(PUBLIC_DIR, 'icon-tip-hat-3d.svg'));
+      res.writeHead(200, {
+        'Content-Type': 'image/svg+xml; charset=utf-8',
+        'Cache-Control': 'public, max-age=86400',
+      });
+      res.end(svg);
+    } catch (e) {
+      res.writeHead(404);
+      res.end('icon-tip-hat-3d.svg not found');
+    }
   } else if (req.url === '/hook-errors') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ errors: readHookErrors() || [] }, null, 2));


### PR DESCRIPTION
Cuts **v1.1.0**. Bundles the last piece of the site-view work (the website brand logo) with the release chores that make the already-merged 1.1.0 work reachable by users.

### Why this matters
`plugin.json` was pinned at `1.0.0`, so **existing users received none of the merged work** (#32–#34) — Claude Code only offers an update when the version string changes. This PR bumps it to `1.1.0` and adds the release scaffolding.

### Changes
- **Website brand logo** in the v2 site-view header (served at `/icon-tip-hat-3d.svg`, on a light disc so it reads on the dark header).
- **`plugin.json` → 1.1.0.**
- **`CHANGELOG.md`** (Keep a Changelog) documenting 1.1.0.
- **SessionStart update-notify hook** (`scripts/update-check-hook.js`): once/day, fail-silent, nudges the user when a newer GitHub Release exists.
- **README "Updating" section** (update commands + auto-update + releases).

### Verification
- `node eval/run.js` → 6/6.
- `stages.test.js`, `validate-checkpoints.test.js` pass.
- Update hook runs fail-safe (exit 0, silent when no newer release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)