### PR TITLE
docs(readme): bump version badge to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ context and learning your platform, so **every run starts smarter than the last*
 
 [![Website](https://img.shields.io/badge/pipecrew.ai-website-2563eb)](https://pipecrew.ai)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757)](https://claude.ai/claude-code)
-[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/pipecrew-ai/pipecrew)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/pipecrew-ai/pipecrew/releases/latest)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 
 [**Website**](https://pipecrew.ai) · [**Install**](#install) · [**Quick start**](#quick-start) · [**Skills**](#skills) · [**Agents**](#agents) · [**Supported stacks**](#supported-tech-stacks)


### PR DESCRIPTION
Updates the stale README version badge (1.0.0 → 1.1.0) and links it to `/releases/latest`. Docs-only.