### PR TITLE
feat(deliver): commit per Phase-5 task (reviewable PRs)

### DIFF
--- a/skills/deliver/phases/phase-5-build.md
+++ b/skills/deliver/phases/phase-5-build.md
@@ -18,6 +18,19 @@ All implementer work is dispatched **via the `Agent` tool in the current session
 
 **ON COMPLETION**: As each agent returns, immediately update the scratchpad — set task status to COMPLETED (or FAILED), record the worktree path, and list the files that changed.
 
+**COMMIT PER TASK** (do this at the same moment, only for a COMPLETED task): commit that task's work as **one logical commit** in its working dir, so each repo's branch reads as one commit per Phase-5 task and its PR is reviewable commit-by-commit. This is also the *only* clean boundary at which a task's changes are isolated: once the next task runs in the same worktree (monorepo) or a 5.5 fix round edits the files, the boundary is gone. Reconstructing per-task commits later in Phase 8 is not reliable — commit here.
+
+```bash
+# working dir = the task's worktree (or the repo's current branch under --no-worktrees)
+git -C {working_dir} add -A
+git -C {working_dir} commit -q -m "feat({repo-short}): {task-title} [{task-id}]"
+```
+
+- **One commit per task.** A repo with a single task → one commit; a monorepo with N sequential tasks → N commits on that repo's branch, in task order.
+- **Nothing to commit** (agent made no file changes, or FAILED) → skip the commit; note it in the scratchpad. Never commit an empty or partial/failed task.
+- **`{repo-short}`** is the repo's short tag from `config.json` (same token Phase 8 uses in PR titles); **`{task-id}`** is the task file id so the commit traces back to the plan.
+- Record the commit SHA in the scratchpad's Implementation Tasks row alongside files-changed.
+
 #### Step 0: Create worktrees
 
 Skip this step entirely if `--no-worktrees` was passed.

--- a/skills/deliver/phases/phase-5.5-code-review.md
+++ b/skills/deliver/phases/phase-5.5-code-review.md
@@ -322,6 +322,13 @@ Per common-rules R6 (scope discipline): touch ONLY the lines the fix list cites.
    - `COMPLETED` if all fix-list items reported done
    - `COMPLETED ⚠` if any items were skipped/failed (note the count)
 
+   **Commit the fix round** (only if it changed files): the fix modifies files already captured by the Phase-5 task commit(s), so give it its own follow-up commit rather than leaving the worktree dirty for Phase 8. This keeps the review-fix visible as a distinct, honest step in the PR:
+   ```bash
+   git -C {worktree_path} add -A
+   git -C {worktree_path} commit -q -m "fix({repo-short}): address review [round-{N}]"
+   ```
+   If the fix round made no file changes (all items skipped/failed), skip the commit. Record the SHA in the scratchpad's Phase 5.5 row.
+
 6. **One fix round per run.** Re-review does not auto-run. If issues remain after the fix round, record them in the scratchpad and report them at Phase 7 — do not auto-re-dispatch. If the user wants a second round, they re-run `/deliver --resume` after inspecting.
 
 **Phase exit:** Phase 5.5 is done when every reviewer has completed, every gate-lane repo has been answered, and every dispatched (auto- or gate-lane) fix round has returned. Because fix rounds are background dispatches, wait for the outstanding ones to finish before advancing. Then continue to Phase 5.75 (security review, if triggered) or Phase 6 (assessment).

--- a/skills/deliver/phases/phase-8-pr-publish.md
+++ b/skills/deliver/phases/phase-8-pr-publish.md
@@ -33,8 +33,8 @@ Workspace:     {slug}
 Phase 6:       {PASSED | NOT_RUN | BLOCKERS_OVERRIDDEN}
 
 Repos to publish ({N}):
-  - {repo1}/branch-{feature-slug}: {N} files changed, +{N} / -{N}
-  - {repo2}/branch-{feature-slug}: {N} files changed, +{N} / -{N}
+  - {repo1}/branch-{feature-slug}: {N} files changed, +{N} / -{N} ({M} commits)
+  - {repo2}/branch-{feature-slug}: {N} files changed, +{N} / -{N} ({M} commits)
   - ...
 
 Will:
@@ -54,8 +54,15 @@ Proceed? (yes / no / yes-with-feedback)
 
 Capture the user's choice. If `no`, jump to Step 8.6.
 
+**Commit structure:** each repo's branch already carries **one commit per Phase-5 task** (committed at task completion — see phase-5-build.md "COMMIT PER TASK") plus a `fix(...)` commit per Phase-5.5 fix round. So the PR reads commit-by-commit and a large single-repo change stays reviewable without splitting the feature into multiple PRs. Phase 8 does **not** re-commit or squash — it publishes the history as built. `{M}` in the summary above is that per-repo commit count (`git -C {worktree} rev-list --count {base}..HEAD`).
+
 **Hard guardrails before any push**:
-- For each repo, run `git status --short` — if there are uncommitted changes in the worktree, refuse to publish that repo and surface the path. The user must commit or stash first.
+- For each repo, run `git status --short`. The worktree should be clean (Phases 5 + 5.5 commit as they go). If a stray uncommitted change remains — e.g. from an inline role that edited files, or a task that reported COMPLETED without committing — do **not** refuse the publish and do **not** silently drop it: commit the remainder as a final catch-all so nothing is lost, then continue.
+  ```bash
+  git -C {worktree_path} add -A
+  git -C {worktree_path} commit -q -m "chore({repo-short}): finalize {feature-slug}"
+  ```
+  Note in the scratchpad: `Phase 8: committed N residual file(s) for {repo} before publish`.
 - Verify no branch is `main` / `master` / `dev` (whatever the workspace's protected branches are per `config.json`). If a feature branch happens to be named one of those, refuse and abort.
 
 ---


### PR DESCRIPTION
Makes `/deliver` build each repo's branch as **one logical commit per Phase-5 task** (+ a `fix()` commit per Phase-5.5 fix round), so a large single-repo change is reviewable commit-by-commit without splitting the feature into multiple PRs.

Also fills a latent gap: the pipeline **never committed** before (Phase 8 would refuse on uncommitted changes). Commits now happen at the task-completion boundary — the only point a task's changes are cleanly isolated.

- **phase-5-build.md** — commit each COMPLETED task at completion (skip empty/failed).
- **phase-5.5-code-review.md** — commit each fix round as its own `fix()` commit.
- **phase-8-pr-publish.md** — publish the history as built (no re-commit/squash), show per-repo commit count, and the old "refuse if uncommitted" guardrail now commits any stray remainder instead of blocking.

Docs-only (skill instructions). `node eval/run.js` → 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)