### PR TITLE
feat(deliver): empty-diff review guard

### DIFF
--- a/scripts/write-review-diff.js
+++ b/scripts/write-review-diff.js
@@ -19,7 +19,9 @@
  * The diff is `git diff <merge-base(base,HEAD)> HEAD` — two-dot from the
  * merge-base, i.e. exactly the changes the branch introduced.
  *
- * Exit 0 on success (including an empty diff — writes an empty file).
+ * Exit 0 on success. An EMPTY diff still exits 0 (writes an empty file) but
+ * prints a distinct `EMPTY DIFF — …` line instead of the byte-count line, so
+ * the caller can detect "nothing committed to review" and skip the reviewer.
  * Exit 1 on usage error or git failure.
  *
  * Zero dependencies — pure Node stdlib. execFileSync (no shell) so a worktree
@@ -78,6 +80,17 @@ catch (e) { console.error(`git diff failed: ${e.message}`); process.exit(1); }
 fs.mkdirSync(path.dirname(out), { recursive: true });
 fs.writeFileSync(out, diff);
 
+const bytes = Buffer.byteLength(diff);
 const lines = diff.length ? diff.split('\n').length : 0;
-console.log(`wrote ${lines} lines (${Buffer.byteLength(diff)} bytes) to ${out} [base=${base} merge-base=${mergeBase.slice(0, 8)}]`);
+if (bytes === 0) {
+  // Empty diff = merge-base(base,HEAD) === HEAD, i.e. the branch introduced no
+  // COMMITTED changes for this repo. Since reviewers diff committed history,
+  // there is literally nothing for them to review. Emit a loud, greppable
+  // signal so Phase 5.5 skips the dispatch instead of running a reviewer
+  // against nothing (the usual cause: a Phase-5 task edited files but was never
+  // committed — see phase-5-build.md "COMMIT PER TASK").
+  console.log(`EMPTY DIFF — no committed changes in ${worktree} against ${base} (merge-base ${mergeBase.slice(0, 8)}). Nothing to review; skip this repo's reviewer. Likely cause: Phase 5 did not commit this repo's task(s).`);
+} else {
+  console.log(`wrote ${lines} lines (${bytes} bytes) to ${out} [base=${base} merge-base=${mergeBase.slice(0, 8)}]`);
+}
 process.exit(0);

--- a/skills/deliver/phases/phase-5.5-code-review.md
+++ b/skills/deliver/phases/phase-5.5-code-review.md
@@ -33,6 +33,17 @@ node {plugin_dir}/scripts/write-review-diff.js --worktree={worktree_path} --out=
 
 Pass the resulting path (`{run_dir}/review/{repo}.diff`) into the reviewer prompt as its `DIFF FILE`. The reviewer `Read`s that file instead of running git. Omit `--base` to let the helper auto-resolve (origin/main → main → dev → master); pass it when the repo's base branch is non-standard.
 
+**Empty-diff guard — do NOT dispatch a reviewer against nothing.** The reviewer diffs *committed* history (`merge-base..HEAD`), so if the helper prints `EMPTY DIFF` (0 bytes) this repo has **no committed changes to review**. Do **not** dispatch its reviewer. Instead, mark the repo's Phase 5.5 row `SKIPPED ⚠` with reason `"empty review diff — no committed changes for {repo}"`, and surface it loudly in the phase summary:
+
+```
+⚠ {repo}: empty review diff — nothing committed to review. Skipped code review.
+  Most likely a Phase-5 task completed but was not committed (see phase-5-build.md
+  "COMMIT PER TASK"). Verify: git -C {worktree_path} status --short  (uncommitted work
+  here means the reviewer — and the eventual PR diff — would miss it).
+```
+
+This converts the old silent failure (reviewer runs against an empty diff and "finds nothing") into a loud, actionable skip. It is distinct from the `--no-review` skip: this one flags a likely uncommitted-work bug, not an intentional opt-out.
+
 **Backend / Worker reviewer — one per affected service (spec_policy-aware)**
 
 Pull the structured services list from the architect's output (do NOT LLM-parse the prose Notes):


### PR DESCRIPTION
Backstops the per-task-commit dependency: reviewers diff committed history, so an uncommitted Phase-5 task would leave an empty diff and the reviewer would silently review nothing.

- `write-review-diff.js` emits a distinct `EMPTY DIFF — …` line (exit 0) when the branch has no committed changes.
- `phase-5.5-code-review.md` skips that repo's reviewer and marks it `SKIPPED ⚠` with a loud, actionable message (distinct from the `--no-review` opt-out).

Tested: empty vs non-empty cases behave correctly. `node eval/run.js` → 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)