### PR TITLE
release: v1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pipecrew",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PipeCrew — a multi-repo agent crew that ships features end-to-end. Discover a project (/discover), deliver a feature (/deliver), review code (/review), assess cross-repo integration (/assess), learn from runs and PRs (/learn), manage agent context (/context-refresh), and manage shared workspace memory (/memory-sync). Supports Spring Boot, React, Next.js, NestJS, FastAPI, Flask, Django, Python workers, AWS CDK, Terraform, and Node mock stacks.",
   "author": {
     "name": "Ramy Hassan"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Or enable hands-off updates once: `/plugin` → **Marketplaces** → `pipecrew` → **Enable auto-update**.
 Watch the [repo Releases](https://github.com/pipecrew-ai/pipecrew/releases) (Watch → Custom → Releases) to be notified of new versions.
 
+## [1.2.0] - 2026-07-01
+
+### Added
+- **Per-stage token totals** in the site-view v2 swimlane headers — see cost
+  distribution across Understand → Contract → Build → Verify → Ship → Learn at a
+  glance (reconciles to the header's total).
+- **`/deliver` commits per Phase-5 task.** Each repo's feature branch is now
+  built as one logical commit per implementation task (plus a `fix()` commit per
+  Phase-5.5 fix round), so a large single-repo change is reviewable
+  commit-by-commit without splitting the feature into multiple PRs. Also fills a
+  gap where the pipeline never committed at all.
+- **Empty-diff review guard.** Reviewers diff committed history, so an
+  uncommitted task would leave them reviewing nothing. `write-review-diff.js`
+  now emits a loud `EMPTY DIFF` signal and Phase 5.5 skips that repo's reviewer
+  with an actionable warning instead of failing silently.
+
 ## [1.1.0] - 2026-07-01
 
 ### Added
@@ -49,5 +65,6 @@ Initial release — multi-repo agent crew for Claude Code: `/discover`, `/delive
 site-view and support for Spring Boot, React, Next.js, NestJS, FastAPI, Flask,
 Django, Python workers, AWS CDK, Terraform, and Node mock stacks.
 
+[1.2.0]: https://github.com/pipecrew-ai/pipecrew/releases/tag/v1.2.0
 [1.1.0]: https://github.com/pipecrew-ai/pipecrew/releases/tag/v1.1.0
 [1.0.0]: https://github.com/pipecrew-ai/pipecrew/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ context and learning your platform, so **every run starts smarter than the last*
 
 [![Website](https://img.shields.io/badge/pipecrew.ai-website-2563eb)](https://pipecrew.ai)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757)](https://claude.ai/claude-code)
-[![Version](https://img.shields.io/badge/version-1.1.0-blue)](https://github.com/pipecrew-ai/pipecrew/releases/latest)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue)](https://github.com/pipecrew-ai/pipecrew/releases/latest)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 
 [**Website**](https://pipecrew.ai) · [**Install**](#install) · [**Quick start**](#quick-start) · [**Skills**](#skills) · [**Agents**](#agents) · [**Supported stacks**](#supported-tech-stacks)


### PR DESCRIPTION
Cuts **v1.2.0** — makes the merged work reachable by users (version-gate bump).

### Included since 1.1.0
- Per-stage token totals in the v2 swimlane headers (#39)
- `/deliver` commits per Phase-5 task + `fix()` per fix round (#40)
- Empty-diff review guard (#41)

Bumps `plugin.json` → 1.2.0, adds the CHANGELOG entry, updates the README badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)