### PR TITLE
feat(site-view): label Build stage "IMPLEMENT · FIX"

### DIFF
--- a/skills/site-view/public/index-v2.html
+++ b/skills/site-view/public/index-v2.html
@@ -2187,7 +2187,7 @@ const STAGES = [
     roles: ['pip', 'archie'],          phases: ['requirements', 'arch'] },
   { id: 'contract',   n: 2, label: 'Contract',   blurb: 'SCHEMAS · API · PLAN',
     roles: ['yara', 'foreman'],        phases: ['spec', 'sync', 'plan'] },
-  { id: 'build',      n: 3, label: 'Build',      blurb: 'IMPLEMENT',
+  { id: 'build',      n: 3, label: 'Build',      blurb: 'IMPLEMENT · FIX',
     roles: ['tya', 'bruno', 'pixel', 'echo', 'stratos'], phases: ['impl'] },
   { id: 'verify',     n: 4, label: 'Verify',     blurb: 'REVIEW · SEC · ASSESS',
     roles: ['crit', 'shield', 'judge'], phases: ['review', 'security', 'assess'] },


### PR DESCRIPTION
Fix rounds re-dispatch implementers, so fix work appears in the Build lane (the `FIX-R*` chips). The Build stage blurb now reads `IMPLEMENT · FIX` to reflect that, matching the other stages' activity-list convention (e.g. Verify's `REVIEW · SEC · ASSESS`). One-line change; v2 JS syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)